### PR TITLE
Firefly/Caddyfile | Strictly use https for headers

### DIFF
--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -1,7 +1,7 @@
 # firefly-iii
 :8081 {
     reverse_proxy {{ HostIp }}:9299
-    header Location http:// https://
+    redir https://{host}{uri}
 }
 
 # bookstack

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -1,6 +1,7 @@
 # firefly-iii
 :8081 {
     reverse_proxy {{ HostIp }}:9299
+    header Location http:// https://
 }
 
 # bookstack

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -1,7 +1,7 @@
 # firefly-iii
 :8081 {
     reverse_proxy {{ HostIp }}:9299
-    redir https://{host}{uri}
+    header Content-Security-Policy upgrade-insecure-requests
 }
 
 # bookstack


### PR DESCRIPTION
This was a breaking change when Google Chrome started prohibiting mixed content requests (mix of HTTP and HTTPS). https://medium.com/geekculture/mixed-content-the-page-at-xxx-was-loaded-over-https-but-requested-an-insecure-yyy-95086e0293f7 gave insights on how to go about solving this problem.