### PR TITLE
Add new job for running postgres

### DIFF
--- a/roles/launch-nomad-jobs/tasks/main.yml
+++ b/roles/launch-nomad-jobs/tasks/main.yml
@@ -186,6 +186,7 @@
     service: "{{ item }}"
   with_items:
     - mysql
+    - postgresql
     - redis
     - firefly
     - bookstack
@@ -200,4 +201,3 @@
     - kavita
     - miniflux
     - souptik
-    - postgresql

--- a/roles/launch-nomad-jobs/tasks/main.yml
+++ b/roles/launch-nomad-jobs/tasks/main.yml
@@ -145,9 +145,9 @@
       include: configure.yml
       vars:
         service: "miniflux"
-        DatabaseUser: "{{ lookup('bitwarden', 'homelab/secrets/rds/postgres/username') }}"
-        DatabasePassword: "{{ lookup('bitwarden', 'homelab/secrets/rds/postgres/password') }}"
-        DatabaseHost: "{{ lookup('bitwarden', 'homelab/secrets/rds/postgres/host') }}"
+        DatabaseUser: "{{ lookup('bitwarden', 'homelab/secrets/postgres/username') }}"
+        DatabasePassword: "{{ lookup('bitwarden', 'homelab/secrets/postgres/password') }}"
+        DatabaseHost: "{{ HOST_EXTERNAL_IPV4 }}"
         MinifluxUsername: "{{ lookup('bitwarden', 'homelab/secrets/miniflux/username') }}"
         MinifluxPassword: "{{ lookup('bitwarden', 'homelab/secrets/miniflux/password') }}"
 
@@ -160,6 +160,13 @@
         SouptikDatabaseName: "{{ lookup('bitwarden', 'homelab/secrets/souptik/database') }}"
         SouptikDebugLog: "{{ lookup('bitwarden', 'homelab/secrets/souptik/debug') }}"
         DatabaseHost: "{{ HOST_EXTERNAL_IPV4 }}"
+
+    - name: Initiate config file building for PostgreSQL
+      include: configure.yml
+      vars:
+        service: "postgresql"
+        DatabaseRootUser: "{{ lookup('bitwarden', 'homelab/secrets/postgresql/root_user') }}"
+        DatabaseRootPassword: "{{ lookup('bitwarden', 'homelab/secrets/postgresql/root_password') }}"
 
 - name: Install the required apt packages
   apt:
@@ -191,6 +198,6 @@
     - ntfy
     - cronicle
     - kavita
-    - mailpile
     - miniflux
     - souptik
+    - postgresql

--- a/roles/launch-nomad-jobs/templates/postgresql.nomad.j2
+++ b/roles/launch-nomad-jobs/templates/postgresql.nomad.j2
@@ -1,0 +1,52 @@
+job "postgresql_job" {
+  datacenters = ["246bp"]
+  type        = "service"
+
+  group "postgresql_group" {
+    count = 1
+
+    network {
+      port "postgresql_port" {
+        static       = 5432
+        to           = 5432
+        host_network = "tailscale"
+      }
+    }
+
+    volume "postgresql_volume" {
+      type      = "host"
+      source    = "postgresql_hdd_volume"
+      read_only = false
+    }
+
+    restart {
+      attempts = 2
+      interval = "10m"
+      delay    = "1m"
+      mode     = "delay"
+    }
+
+    task "postgresql_server" {
+      driver = "docker"
+
+      env = {
+        POSTGRES_USER = "{{ DatabaseRootUser }}"
+        POSTGRES_PASSWORD = "{{ DatabaseRootPassword }}"
+      }
+
+      volume_mount {
+        volume      = "postgresql_volume"
+        destination = "/var/lib/postgresql/data"
+        read_only   = false
+      }
+
+      config {
+        image = "postgres:14.5"
+
+        ports = ["postgresql_port"]
+
+      }
+    }
+
+  }
+}

--- a/roles/launch-orchestrators/templates/nomad.hcl.j2
+++ b/roles/launch-orchestrators/templates/nomad.hcl.j2
@@ -122,6 +122,10 @@ client {
   host_volume "souptik_hdd_uploads_volume" {
     path = "{{ hdd_mount_path }}/homelab/souptik/uploads"
   }
+
+  host_volume "postgresql_hdd_volume" {
+    path = "{{ hdd_mount_path }}/homelab/postgresql"
+  }
 }
 
 plugin "docker" {


### PR DESCRIPTION
I had a dependency on AWS RDS in running a postgres node. But no longer. I'm rolling my own Postgres. The only user of this postgres will be miniflux as of now. From now, I can onboard more services which require postgres.
Post deploy: The performance of miniflux has jumped. It is also expected given the latency to bring data from the AWS VPC was quite high, and here is just the HDD next door :smile: 