### PR TITLE
Immich image tag update

### DIFF
--- a/roles/launch-nomad-jobs/templates/immich.nomad.j2
+++ b/roles/launch-nomad-jobs/templates/immich.nomad.j2
@@ -139,8 +139,6 @@ job "immich_job" {
 
       config {
         image = "altran1502/immich-machine-learning:release"
-        command = "/bin/sh"
-        args    = ["./entrypoint.sh"]
       }
     }
 

--- a/roles/launch-nomad-jobs/templates/immich.nomad.j2
+++ b/roles/launch-nomad-jobs/templates/immich.nomad.j2
@@ -69,7 +69,7 @@ job "immich_job" {
       }
 
       config {
-        image = "altran1502/immich-server:latest"
+        image = "altran1502/immich-server:release"
         command = "/bin/sh"
         args    = ["./start-server.sh"]
         ports = ["immich_server_port"]
@@ -104,7 +104,7 @@ job "immich_job" {
       }
 
       config {
-        image = "altran1502/immich-server:latest"
+        image = "altran1502/immich-server:release"
         command = "/bin/sh"
         args    = ["./start-microservices.sh"]
       }
@@ -138,7 +138,7 @@ job "immich_job" {
       }
 
       config {
-        image = "altran1502/immich-machine-learning:latest"
+        image = "altran1502/immich-machine-learning:release"
         command = "/bin/sh"
         args    = ["./entrypoint.sh"]
       }
@@ -152,7 +152,7 @@ job "immich_job" {
       }
 
       config {
-        image = "altran1502/immich-web:latest"
+        image = "altran1502/immich-web:release"
         command = "/bin/sh"
         args    = ["./entrypoint.sh"]
         ports = ["immich_web_port"]


### PR DESCRIPTION
Immich has introduced some breaking changes in their release tagging as well as in the API structuring. Due to this the mobile app is no longer able to synchronize photos with the server (damn the backlog!).