### PR TITLE
Deploy texas-fold-em via upstream chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ My homelab is a single-node x64 (previously ARM) machine, and applications are d
 | ntfy           | Push notifications                                         | https://ntfy.sh/                         |
 | MotionEye      | Camera / motion detection frontend                         | https://github.com/motioneye-project/motioneye |
 | Synt           | LLM chat archiving                                         | https://github.com/rounakdatta/synt      |
+| texas-fold-em  | fold.money refresh-token broker (in-cluster API)           | https://github.com/rounakdatta/texas-fold-em |
 | Hugo sites     | Personal static sites (rounak2018 / rounak2020 / rounak2025) | https://gohugo.io/                       |
 
 ### Supporting infrastructure

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -213,6 +213,15 @@
           db-username: nextcloud/db_username
           db-password: nextcloud/db_password
 
+      # texas-fold-em bearer keys
+      # Keys match what the chart's deployment.yaml references via
+      # secretKeyRef (broker-key, admin-key).
+      - name: texas-fold-em-credentials
+        namespace: apps
+        data:
+          broker-key: texas-fold-em/broker_key
+          admin-key: texas-fold-em/admin_key
+
       # tinyauth credentials (replaces authelia)
       # Keys match the env var names tinyauth reads via valueFrom in
       # kubernetes/tinyauth/values.yaml — see env: section there.

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ntfy/
   - motioneye/
   - synt/
+  - texas-fold-em/

--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: apps
+
+helmCharts:
+  - name: texas-fold-em
+    repo: oci://ghcr.io/rounakdatta/charts
+    version: 0.2.0
+    releaseName: texas-fold-em
+    namespace: apps
+    valuesFile: values.yaml

--- a/kubernetes/apps/texas-fold-em/values.yaml
+++ b/kubernetes/apps/texas-fold-em/values.yaml
@@ -1,0 +1,28 @@
+# Values for the rounakdatta/texas-fold-em chart 0.2.0.
+# Chart source: oci://ghcr.io/rounakdatta/charts/texas-fold-em
+#
+# Texas-fold-em is a long-running Go broker that holds a fold.money refresh
+# token and issues short-lived access tokens to in-cluster consumers via
+# /token. Single-replica by design (single writer to state.json).
+
+image:
+  repository: ghcr.io/rounakdatta/texas-fold-em
+  tag: latest
+  pullPolicy: Always
+
+service:
+  type: ClusterIP
+  port: 8080
+
+persistence:
+  enabled: true
+  storageClass: local-path
+  size: 1Gi
+  accessMode: ReadWriteOnce
+
+# Use the texas-fold-em-credentials Secret synced from Bitwarden by ansible.
+# Keys: broker-key, admin-key. The chart skips creating its own Secret when
+# secret.create=false + secret.existingSecret is set.
+secret:
+  create: false
+  existingSecret: texas-fold-em-credentials


### PR DESCRIPTION
## Summary
- Add `rounakdatta/texas-fold-em` chart 0.2.0 (OCI on GHCR) to `apps` namespace
- Chart 0.2.0 was just harmonized upstream to match the synt chart's conventions:
  - `templates/_helpers.tpl` with `texas-fold-em.{labels,selectorLabels}`
  - `persistence.existingClaim` support so chart skips PVC creation when an existing PVC is supplied
  - All templates now use the labels helper instead of inline `app.kubernetes.io/*`
- `secret.create=false` + `existingSecret: texas-fold-em-credentials` so the keys come from the Bitwarden-synced Secret rather than being inlined into chart values
- `ansible/playbook.yml` syncs the new Secret with two keys: `broker-key` and `admin-key` (from Bitwarden paths `texas-fold-em/broker_key` and `texas-fold-em/admin_key`)
- README's app table updated to include texas-fold-em

## Why no Ingress
Texas-fold-em is an in-cluster broker — consumers reach it on `texas-fold-em.apps.svc.cluster.local:8080` with the broker bearer key. Bootstrap is done via `kubectl port-forward`. Adding a standalone Ingress can come later if external access is ever needed.

## Test plan
- [x] Chart 0.2.0 published cleanly to `oci://ghcr.io/rounakdatta/charts/texas-fold-em` (workflow run on `rounakdatta/texas-fold-em` ref `v0.2.0` succeeded)
- [x] `helm template` against our values renders Service, PVC (chart-managed), Deployment with correct env wiring; no chart-managed Secret rendered (since `secret.create=false`)
- [ ] Bitwarden entries `texas-fold-em/broker_key` and `texas-fold-em/admin_key` populated *(pending — values to paste in chat)*
- [ ] Workflow_dispatch deploys cleanly; pod 1/1 Running; `texas-fold-em.apps.svc.cluster.local:8080/livez` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)