### PR TITLE
Set tinyauth login background image

### DIFF
--- a/kubernetes/tinyauth/values.yaml
+++ b/kubernetes/tinyauth/values.yaml
@@ -46,6 +46,8 @@ tinyauth:
 
   ui:
     title: "taptappers.club"
+    # External URL — frontend renders this as a CSS background-image
+    backgroundImage: "https://i.ibb.co/bR3DF055/auth-background.jpg"
 
   log:
     level: info


### PR DESCRIPTION
## Summary
Override the default tinyauth login background by setting `tinyauth.ui.backgroundImage` to an external HTTPS URL. Frontend uses the value as a CSS background-image, so a remote URL works without needing to mount an in-cluster volume.

Image: https://i.ibb.co/bR3DF055/auth-background.jpg

## Test plan
- [ ] After merge + deploy, https://auth.taptappers.club shows the new background

🤖 Generated with [Claude Code](https://claude.com/claude-code)