### PR TITLE
Add gemini-api-key + firefly-pat to texas-fold-em-credentials

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -213,14 +213,20 @@
           db-username: nextcloud/db_username
           db-password: nextcloud/db_password
 
-      # texas-fold-em bearer keys
-      # Keys match what the chart's deployment.yaml references via
-      # secretKeyRef (broker-key, admin-key).
+      # texas-fold-em credentials (consolidated)
+      # broker-key: bearer auth for /token consumers
+      # admin-key:  bearer auth for /init and /admin/*
+      # firefly-pat: long-lived PAT for the integration's firefly client
+      #              (sync, FTS5 indexing, push)
+      # gemini-api-key: Google AI Studio key for Tier-3 RAG classifier
+      #                 (gemini-3.1-flash-lite)
       - name: texas-fold-em-credentials
         namespace: apps
         data:
           broker-key: texas-fold-em/broker_key
           admin-key: texas-fold-em/admin_key
+          firefly-pat: firefly/personal_access_token
+          gemini-api-key: gemini/api_key
 
       # tinyauth credentials (replaces authelia)
       # Keys match the env var names tinyauth reads via valueFrom in


### PR DESCRIPTION
## Summary
Two more keys added to the existing \`texas-fold-em-credentials\` Secret, synced from Bitwarden:

- \`gemini-api-key\` — Google AI Studio key for the upcoming integration's Tier-3 RAG classifier (\`gemini-3.1-flash-lite\`)
- \`firefly-pat\` — long-lived Firefly III PAT for the integration's firefly client

The chart's deployment doesn't reference these yet; that wiring lands with chart 0.3.0 once the integration code starts reading them. Adding them to the Secret first is decoupled and safe — no pod restart, no runtime dependency.

## Test plan
- [x] Bitwarden items \`gemini/api_key\` and \`firefly/personal_access_token\` exist in the \`taptappers.club / k3s\` collection (verified via \`bw get password\`)
- [ ] After deploy, \`kubectl -n apps get secret texas-fold-em-credentials -o jsonpath='{.data}' | jq 'keys'\` shows all 4 keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)