### PR TITLE
Enable texas-fold-em fold→firefly integration

### DIFF
--- a/kubernetes/apps/texas-fold-em/ingress.yaml
+++ b/kubernetes/apps/texas-fold-em/ingress.yaml
@@ -1,0 +1,39 @@
+---
+# Tinyauth-protected ingress to texas-fold-em's review UI only.
+#
+# We deliberately scope the ingress to /admin/ui/* paths so the
+# bearer-key-gated JSON endpoints (/admin/firefly/sync, /admin/classify,
+# /admin/push/{uuid}, etc.) stay reachable ONLY via in-cluster Service
+# URL. The UI is sufficient for human review; programmatic admin
+# operations can be invoked via kubectl-port-forward when needed.
+#
+# Auth flow: any request to fold.taptappers.club hits Traefik →
+# tinyauth ForwardAuth → Google OAuth (if not already logged in) →
+# back to Traefik → texas-fold-em pod. Once authed, the texas-fold-em
+# pod itself is in AuthModeBypass (TEXAS_FOLDEM_UI_COOKIE_AUTH=false).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: texas-fold-em-ui
+  namespace: apps
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.middlewares: tinyauth-tinyauth@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - fold.taptappers.club
+      secretName: fold-tls-secret
+  rules:
+    - host: fold.taptappers.club
+      http:
+        paths:
+          - path: /admin/ui
+            pathType: Prefix
+            backend:
+              service:
+                name: texas-fold-em
+                port:
+                  number: 8080

--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,10 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.2.0
+    version: 0.3.0
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml
+
+resources:
+  - ingress.yaml

--- a/kubernetes/apps/texas-fold-em/values.yaml
+++ b/kubernetes/apps/texas-fold-em/values.yaml
@@ -1,4 +1,4 @@
-# Values for the rounakdatta/texas-fold-em chart 0.2.0.
+# Values for the rounakdatta/texas-fold-em chart 0.3.0.
 # Chart source: oci://ghcr.io/rounakdatta/charts/texas-fold-em
 #
 # Texas-fold-em is a long-running Go broker that holds a fold.money refresh
@@ -21,8 +21,56 @@ persistence:
   accessMode: ReadWriteOnce
 
 # Use the texas-fold-em-credentials Secret synced from Bitwarden by ansible.
-# Keys: broker-key, admin-key. The chart skips creating its own Secret when
-# secret.create=false + secret.existingSecret is set.
+# Keys (synced by ansible/playbook.yml):
+#   - broker-key       — bearer auth for /token consumers
+#   - admin-key        — bearer auth for /init and /admin/*
+#   - firefly-pat      — long-lived Firefly III PAT (integration)
+#   - gemini-api-key   — Google AI Studio key (integration Tier-3 RAG)
 secret:
   create: false
   existingSecret: texas-fold-em-credentials
+
+# fold→firefly classification subsystem. Wired into the pod via extraEnv
+# (chart 0.3.0 added support for valueFrom secret references). The
+# integration code is gated by TEXAS_FOLDEM_INTEGRATION_ENABLED so a
+# stock deploy without these env vars behaves exactly as the broker did
+# before — they're only consulted when the flag is true.
+extraEnv:
+  - name: TEXAS_FOLDEM_INTEGRATION_ENABLED
+    value: "true"
+  - name: TEXAS_FOLDEM_FIREFLY_BASE
+    value: "http://firefly.apps.svc.cluster.local:8080"
+  - name: TEXAS_FOLDEM_FIREFLY_PAT
+    valueFrom:
+      secretKeyRef:
+        name: texas-fold-em-credentials
+        key: firefly-pat
+  - name: TEXAS_FOLDEM_GEMINI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: texas-fold-em-credentials
+        key: gemini-api-key
+  - name: TEXAS_FOLDEM_GEMINI_MODEL
+    value: "gemini-3.1-flash-lite"
+  # Periodic sync disabled at first deploy — flip to "1h" after we've
+  # confirmed manual /admin/fold/sync + /admin/classify behave correctly
+  # against real fold + firefly data.
+  - name: TEXAS_FOLDEM_PERIODIC_SYNC_EVERY
+    value: "0"
+  - name: TEXAS_FOLDEM_PERIODIC_SYNC_LIMIT
+    value: "50"
+  # Read-only kill-switch for the firefly write surface. Initial deploy
+  # leaves it OFF so we can preview-only first; flip to "true" if we
+  # ever need to halt all writes without redeploying.
+  - name: TEXAS_FOLDEM_FIREFLY_READONLY
+    value: "false"
+  # UI auth: bypass at the texas-fold-em layer because the cluster
+  # ingress (added separately) puts tinyauth ForwardAuth in front. For
+  # local dev against a port-forward, set to "true" to require the
+  # tfe-admin cookie set by /admin/ui/login.
+  - name: TEXAS_FOLDEM_UI_COOKIE_AUTH
+    value: "false"
+  # Persistent on-disk state for the integration's SQLite. Lives on the
+  # same /data PVC as the broker's state.json but in a separate file.
+  - name: TEXAS_FOLDEM_STAGING_DB_PATH
+    value: "/data/staging.db"


### PR DESCRIPTION
## Summary
Bumps the texas-fold-em chart from 0.2.0 → 0.3.0 (which adds \`extraEnv\` support) and turns on the integration subsystem.

## What changes
- Wires \`firefly-pat\` and \`gemini-api-key\` (already synced into \`texas-fold-em-credentials\` from Bitwarden) into the pod via the chart's new \`extraEnv\`.
- Sets plain-string toggles for the integration's behaviour:
  - \`TEXAS_FOLDEM_INTEGRATION_ENABLED=true\`
  - \`TEXAS_FOLDEM_PERIODIC_SYNC_EVERY=0\` (manual-only at first deploy — flip to \`1h\` after we've confirmed manual sync + classify work end-to-end)
  - \`TEXAS_FOLDEM_FIREFLY_READONLY=false\` (push surface live; flip to \`true\` if anything looks off)
  - \`TEXAS_FOLDEM_UI_COOKIE_AUTH=false\` (tinyauth fronts the ingress)
  - \`TEXAS_FOLDEM_GEMINI_MODEL=gemini-3.1-flash-lite\`
- New \`ingress.yaml\` at \`fold.taptappers.club\`, **scoped to \`/admin/ui/*\` paths only** so the bearer-key-gated JSON endpoints (firefly/sync, classify, push) stay reachable only via the in-cluster Service URL — not the public ingress.

## Manual follow-up after merge
1. Add a \`fold.taptappers.club\` DNS A/CNAME pointing at the cluster's ingress IP (Tailscale 100.100.47.17 for internal, or wherever the homelab Cloudflare DNS is currently pointed).
2. After deploy, browse \`https://fold.taptappers.club/admin/ui/\` (Google OAuth via tinyauth) — should land on the empty review queue.
3. From a port-forward to the in-cluster Service, kick off a manual sync:
   \`\`\`
   ADMIN=$(kubectl -n apps get secret texas-fold-em-credentials -o jsonpath='{.data.admin-key}' | base64 -d)
   kubectl -n apps port-forward svc/texas-fold-em 8080:8080 &
   curl -X POST http://localhost:8080/admin/firefly/sync -H "Authorization: Bearer $ADMIN"
   curl -X POST http://localhost:8080/admin/fold/sync   -H "Authorization: Bearer $ADMIN"
   curl -X POST http://localhost:8080/admin/classify    -H "Authorization: Bearer $ADMIN"
   \`\`\`
4. Then revisit \`/admin/ui/\` — should show staged fold transactions with classifier proposals.

## Test plan
- [x] \`helm pull\` of chart 0.3.0 succeeds against GHCR
- [x] \`helm template\` against this PR's values renders \`extraEnv\` block correctly with the secretKeyRef for firefly-pat + gemini-api-key
- [ ] After deploy: pod 1/1, \`/health\` shows the integration block, broker chain still rolling
- [ ] DNS + ingress live; \`/admin/ui/\` reachable behind Google OAuth
- [ ] Manual sync + classify cycle succeeds against live firefly + fold

🤖 Generated with [Claude Code](https://claude.com/claude-code)