### PR TITLE
texas-fold-em: swap Tier-3 LLM from Gemini to DeepSeek

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -218,15 +218,18 @@
       # admin-key:  bearer auth for /init and /admin/*
       # firefly-pat: long-lived PAT for the integration's firefly client
       #              (sync, FTS5 indexing, push)
-      # gemini-api-key: Google AI Studio key for Tier-3 RAG classifier
-      #                 (gemini-3.1-flash-lite)
+      # llm-api-key: OpenAI-compatible API key for the Tier-3 LLM
+      #              classifier. Sourced from deepseek/api_key
+      #              (DeepSeek's OpenAI-compatible endpoint); swap the
+      #              Bitwarden source to openai/api_key or similar to
+      #              repoint at a different provider.
       - name: texas-fold-em-credentials
         namespace: apps
         data:
           broker-key: texas-fold-em/broker_key
           admin-key: texas-fold-em/admin_key
           firefly-pat: firefly/personal_access_token
-          gemini-api-key: gemini/api_key
+          llm-api-key: deepseek/api_key
 
       # tinyauth credentials (replaces authelia)
       # Keys match the env var names tinyauth reads via valueFrom in

--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.3.0
+    version: 0.4.0_755b538
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/texas-fold-em/values.yaml
+++ b/kubernetes/apps/texas-fold-em/values.yaml
@@ -1,9 +1,12 @@
-# Values for the rounakdatta/texas-fold-em chart 0.3.0.
+# Values for the rounakdatta/texas-fold-em chart.
 # Chart source: oci://ghcr.io/rounakdatta/charts/texas-fold-em
 #
 # Texas-fold-em is a long-running Go broker that holds a fold.money refresh
 # token and issues short-lived access tokens to in-cluster consumers via
 # /token. Single-replica by design (single writer to state.json).
+#
+# Chart 0.4.0 replaced the Gemini-specific Tier-3 client with a generic
+# OpenAI-compatible LLM client, defaulting to DeepSeek.
 
 image:
   repository: ghcr.io/rounakdatta/texas-fold-em
@@ -22,10 +25,11 @@ persistence:
 
 # Use the texas-fold-em-credentials Secret synced from Bitwarden by ansible.
 # Keys (synced by ansible/playbook.yml):
-#   - broker-key       — bearer auth for /token consumers
-#   - admin-key        — bearer auth for /init and /admin/*
-#   - firefly-pat      — long-lived Firefly III PAT (integration)
-#   - gemini-api-key   — Google AI Studio key (integration Tier-3 RAG)
+#   - broker-key   — bearer auth for /token consumers
+#   - admin-key    — bearer auth for /init and /admin/*
+#   - firefly-pat  — long-lived Firefly III PAT (integration)
+#   - llm-api-key  — OpenAI-compatible LLM key (integration Tier-3 RAG;
+#                    currently sourced from deepseek/api_key in Bitwarden)
 secret:
   create: false
   existingSecret: texas-fold-em-credentials
@@ -45,13 +49,19 @@ extraEnv:
       secretKeyRef:
         name: texas-fold-em-credentials
         key: firefly-pat
-  - name: TEXAS_FOLDEM_GEMINI_API_KEY
+  - name: TEXAS_FOLDEM_LLM_API_KEY
     valueFrom:
       secretKeyRef:
         name: texas-fold-em-credentials
-        key: gemini-api-key
-  - name: TEXAS_FOLDEM_GEMINI_MODEL
-    value: "gemini-3.1-flash-lite"
+        key: llm-api-key
+  # LLM_MODEL / LLM_BASE_URL default to deepseek-v4-flash on
+  # https://api.deepseek.com/v1 — uncomment to override (e.g. swap to
+  # deepseek-v4-pro for higher accuracy on tricky transactions, or
+  # repoint LLM_BASE_URL at OpenAI / Groq with a matching key).
+  # - name: TEXAS_FOLDEM_LLM_MODEL
+  #   value: "deepseek-v4-pro"
+  # - name: TEXAS_FOLDEM_LLM_BASE_URL
+  #   value: "https://api.openai.com/v1"
   # Periodic sync disabled at first deploy — flip to "1h" after we've
   # confirmed manual /admin/fold/sync + /admin/classify behave correctly
   # against real fold + firefly data.


### PR DESCRIPTION
## Summary

- Pin texas-fold-em chart to 0.4.0_755b538 (drops the broken \`gemini-3.1-flash-lite\` config, defaults to DeepSeek)
- Rename K8s Secret field \`gemini-api-key\` → \`llm-api-key\`, sourced from \`deepseek/api_key\` in Bitwarden taptappers.club > k3s
- Rename env vars in extraEnv to match the new chart's \`TEXAS_FOLDEM_LLM_*\` names; drop the explicit model override (chart default is \`deepseek-v4-flash\`)

## Test plan

- [x] Bitwarden \`deepseek/api_key\` item created (verified live against \`api.deepseek.com\` — balance ≥ 0, returns expected envelope)
- [x] texas-fold-em chart 0.4.0_755b538 confirmed published on GHCR
- [ ] After merge: deploy-stuff workflow syncs new \`llm-api-key\` field + rolls deployment; pod logs should show \`llm_model=deepseek-v4-flash\` and no more 402 errors
- [ ] After deploy: \`POST /admin/classify?scope=all\` to reprocess all unconfirmed rows through the new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)