### PR TITLE
tinyauth: optimize login background image (1.7 MB → ~0.5 MB webp)

### DIFF
--- a/kubernetes/tinyauth/values.yaml
+++ b/kubernetes/tinyauth/values.yaml
@@ -46,8 +46,9 @@ tinyauth:
 
   ui:
     title: "taptappers.club"
-    # External URL — frontend renders this as a CSS background-image
-    backgroundImage: "https://i.ibb.co/bR3DF055/auth-background.jpg"
+    # External URL (ImgBB) — frontend renders this as a CSS background-image.
+    # Optimized: 1920px webp @ q82, EXIF-stripped (~0.5 MB, down from a 1.7 MB phone photo).
+    backgroundImage: "https://i.ibb.co/Vp00tQ0J/auth-background.webp"
 
   log:
     level: info


### PR DESCRIPTION
## What

Swaps the tinyauth login-page `backgroundImage` to an optimized image and records provenance in a comment.

`kubernetes/tinyauth/values.yaml`:
- old: `https://i.ibb.co/bR3DF055/auth-background.jpg` — 4624×3472, **1.7 MB**, full Xiaomi/Picasa EXIF
- new: `https://i.ibb.co/Vp00tQ0J/auth-background.webp` — 1920×1442, **~0.5 MB** (ImgBB's CDN serves an even smaller ~110 KB variant)

## Why

The backdrop was a straight-off-the-phone photo and loaded noticeably slowly. Optimization:
- **Downscaled** 4624 → 1920px on the long edge (a full-screen login backdrop never needs more — biggest load-time win).
- **Re-encoded** at quality 82, which preserves color/vibrancy fully (vibrancy is a quality/saturation property, not resolution).
- **Stripped EXIF** — removes the leaked `Xiaomi / 23049PCD8I / Picasa / capture-timestamp` metadata from a public page.

Net: ~70% smaller, visually identical, faster first paint. tinyauth renders the value as a CSS `background-image` browser-side, so webp is safe across all current browsers.

## Notes

- tinyauth has no reliable way to serve a *local* file (the `/resources/` path 404s — see upstream issue #564), so the image stays hosted on ImgBB and this is a one-line URL swap.
- No cluster-side behavior changes; merging triggers the usual `deploy-stuff` apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
