### PR TITLE
snibox: fix login CSRF 422 by pinning Origin header at Traefik

### DIFF
--- a/kubernetes/apps/snibox/ingress.yaml
+++ b/kubernetes/apps/snibox/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.middlewares: tinyauth-tinyauth@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: tinyauth-tinyauth@kubernetescrd,apps-snibox-origin-fix@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/kubernetes/apps/snibox/kustomization.yaml
+++ b/kubernetes/apps/snibox/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - middleware.yaml

--- a/kubernetes/apps/snibox/middleware.yaml
+++ b/kubernetes/apps/snibox/middleware.yaml
@@ -1,0 +1,23 @@
+---
+# Traefik headers Middleware to fix the Rails CSRF Origin check behind TLS termination.
+#
+# Traefik terminates TLS at the websecure entrypoint and forwards to the snibox pod
+# over plain HTTP, rewriting the request's Origin header scheme to http://. Rails 5.2
+# CSRF protection (forgery_protection_origin_check, enabled by default) compares the
+# Origin header against request.base_url (which is https, derived from Traefik's
+# X-Forwarded-Proto: https) and rejects the http/https mismatch with HTTP 422
+# ActionController::InvalidAuthenticityToken on login ("The change you wanted was
+# rejected").
+#
+# Forcing Origin back to the canonical https URL makes the origin check pass. The
+# token-based half of CSRF protection (authenticity_token) stays fully active, and
+# snibox is single-host so pinning the Origin is safe.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: snibox-origin-fix
+  namespace: apps
+spec:
+  headers:
+    customRequestHeaders:
+      Origin: "https://snibox.taptappers.club"


### PR DESCRIPTION
## Problem

Logging into Snibox failed with **HTTP 422 "The change you wanted was rejected"** — Rails `ActionController::InvalidAuthenticityToken`. Not a credentials problem.

## Root cause

Traefik terminates TLS at the `websecure` entrypoint and forwards to the snibox pod over plain HTTP, **rewriting the request `Origin` header from `https://` → `http://`**. Rails 5.2 CSRF protection includes a strict Origin check (`forgery_protection_origin_check`, enabled by default) that compares the `Origin` header to `request.base_url` — which is correctly `https://` (via `X-Forwarded-Proto`). The `http` vs `https` mismatch is rejected with 422.

Proven with probes:

| Test | `Origin` reaching pod | Result |
|---|---|---|
| Browser `fetch` (browser *guarantees* `https` Origin) | `http://…` | 422 — origin mismatch |
| Request sent directly to the pod, bypassing Traefik | `https://…` (faithful) | proves the app doesn't downgrade |

So the downgrade happens in **Traefik**, not the application or the credentials.

## Fix

Add a Traefik `headers` Middleware (`snibox-origin-fix`) that pins `Origin: https://snibox.taptappers.club`, wired into the ingress after the tinyauth forward-auth. The origin check then passes; **token-based CSRF protection (`authenticity_token`) stays fully active**. Single-host app, so pinning the Origin is safe.

## Verification

Post-fix, the pod log flipped from:

```
HTTP Origin header (http://snibox.taptappers.club) didn't match request.base_url (https://snibox.taptappers.club)
```

to the normal token check — i.e. the origin check now passes.

> Note: this was already `kubectl apply`-ed to the live cluster to confirm the fix works end-to-end. This PR codifies that state so it survives `make deploy` and cluster rebuilds (the repo is the source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
