### PR TITLE
texas-fold-em: bump chart 0.7.0 → 0.8.0

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.7.0
+    version: 0.8.0
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Bumps the texas-fold-em chart from 0.7.0 to 0.8.0 ([release](https://github.com/rounakdatta/texas-fold-em/releases/tag/v0.8.0)).

## What 0.8.0 brings
- **Tier 3 proposes new firefly expense accounts by name** for novel merchants — firefly auto-creates the account on push. Fixes the class of bug where e.g. a "United Airlines" flight landed on a generic catch-all destination even though the model had the right card (Scapia) and category (Travel).
- **Review-list filter by source account** (+ a small filter framework).
- A dev-only local classifier sandbox (no deploy impact).

## Deploy notes
- Single change: `helmCharts[texas-fold-em].version 0.7.0 → 0.8.0`. Chart default image tag moves with it (0.8.0); no values change needed.
- **Migration 00007** (`proposed_/confirmed_destination_account_name` on `staged_fold_txns`) runs via goose on pod start. Additive columns only — safe, no backfill in the migration itself.
- Single-writer as always (replicaCount 1); the rollout recreates the one pod against the existing `/data` PVC.

## After rollout
One-shot `POST /admin/classify?scope=all` re-classifies the stale backlog (~780 rows classified before the fold-accounts mirror) with the new source-grounding + destination behaviour. Writes nothing to firefly; idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)