### PR TITLE
texas-fold-em: bump chart 0.8.0 → 0.8.1

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.8.0
+    version: 0.8.1
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Bumps texas-fold-em `0.8.0 → 0.8.1` ([release](https://github.com/rounakdatta/texas-fold-em/releases/tag/v0.8.1)).

**0.8.1**: parallelizes the classifier's Tier-3 LLM calls across a bounded worker pool (`TEXAS_FOLDEM_CLASSIFY_CONCURRENCY`, default 8), so a `POST /admin/classify?scope=all` backfill drops from hours to ~15–25 min.

- Single change: `helmCharts[texas-fold-em].version 0.8.0 → 0.8.1`.
- **No schema change** (no new migration); just the binary. Single-writer pod recreates against the existing `/data` PVC.
- Default concurrency 8 applies without a values change; add to `extraEnv` only to tune.

After rollout I'll run the `scope=all` backfill (now fast) to re-classify the stale ~780 rows with 0.8.0's source-grounding + new-destination behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)