### PR TITLE
texas-fold-em: bump chart 0.8.1 → 0.8.2 + firefly public URL

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.8.1
+    version: 0.8.2
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/texas-fold-em/values.yaml
+++ b/kubernetes/apps/texas-fold-em/values.yaml
@@ -88,3 +88,8 @@ extraEnv:
   # same /data PVC as the broker's state.json but in a separate file.
   - name: TEXAS_FOLDEM_STAGING_DB_PATH
     value: "/data/staging.db"
+  # Public firefly URL — used only by the review UI to deep-link pushed
+  # rows to their firefly transaction (0.8.2+). Distinct from FIREFLY_BASE
+  # (the in-cluster API URL, which a browser can't reach).
+  - name: TEXAS_FOLDEM_FIREFLY_PUBLIC_URL
+    value: "https://firefly.taptappers.club"


### PR DESCRIPTION
Bumps texas-fold-em `0.8.1 → 0.8.2` ([release](https://github.com/rounakdatta/texas-fold-em/releases/tag/v0.8.2)).

**0.8.2 — review-UI cockpit:**
- "all" view with per-row colour-coded status icons
- clearer columns (When · Amount · Source · Destination · Category)
- battery-style confidence gauge
- firefly deep-links on pushed rows
- reclassify-selected (checkbox + button to re-run the classifier on chosen rows)

**Changes:** chart version `0.8.1 → 0.8.2`, plus a new `TEXAS_FOLDEM_FIREFLY_PUBLIC_URL=https://firefly.taptappers.club` so the firefly deep-links resolve to the browser-facing host (the existing `FIREFLY_BASE` is the in-cluster API URL). **No schema change** — code-only rollout against the existing `/data` PVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)