### PR TITLE
texas-fold-em: bump chart 0.8.2 → 0.8.3

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.8.2
+    version: 0.8.3
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Bumps texas-fold-em `0.8.2 → 0.8.3` ([release](https://github.com/rounakdatta/texas-fold-em/releases/tag/v0.8.3)). Source is never blank when fold knows the paying card; cron auto-syncs the card mirror. Migration 00008 (additive). No new env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)