### PR TITLE
texas-fold-em: 0.8.3 → 0.9.0 (deterministic source + firefly accounts mirror)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.8.3
+    version: 0.9.0
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Pins texas-fold-em **0.9.0**, which fixes the source-account hallucination at the root.

- **Mirror firefly's real account list** — an asset the user just created (e.g. "Ixigo AU Bank Credit Card") is now visible to the classifier immediately, instead of only after it has transaction history.
- **Deterministic OUTGOING source** — resolved from fold's `account_id` and overriding any tier's guess, so an AU-card charge can never land on "Axis Bank Ace" again. No confident match → propose the fold card name + review (never a wrong card).

Adds `POST /admin/firefly/accounts/sync`; the cron tick refreshes the firefly account mirror automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)