### PR TITLE
texas-fold-em: 0.9.0 → 0.9.1 (detail-view source name from mirror)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.9.0
+    version: 0.9.1
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Detail edit form renders a source resolved to a freshly-created firefly asset (no transaction history) by name instead of blank. List view was already correct in 0.9.0; this completes the UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)