### PR TITLE
texas-fold-em: 0.9.1 → 0.9.2 (source match ignores payment network)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.9.1
+    version: 0.9.2
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Fixes single-brand cards (Scapia) resolving to a proposed duplicate asset instead of the existing firefly asset — the payment network token (Visa/RuPay) was sinking the match. See rounakdatta/texas-fold-em#40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)