### PR TITLE
velero: exclude cert-manager ephemeral resources from backups

### DIFF
--- a/kubernetes/infrastructure/velero/schedule-nightly.yaml
+++ b/kubernetes/infrastructure/velero/schedule-nightly.yaml
@@ -20,6 +20,17 @@ spec:
     excludedResources:
       - events
       - events.events.k8s.io
+      # cert-manager's request/order/challenge objects are regenerable runtime
+      # children of Certificates. Backing them up means a DR restore re-seeds
+      # stale CertificateRequests that collide with cert-manager's own next
+      # revision name (<cert>-N), deadlocking renewals on "already exists" until
+      # the certs silently expire. This bit us on 2026-06: 2026-03-30 leftovers
+      # (restored during the March DR) blocked renewals for 8 apps. The *-tls
+      # Secrets and Certificates ARE still backed up, so a restore reuses the
+      # existing cert material (no re-issuance / Let's Encrypt rate-limit risk).
+      - certificaterequests.cert-manager.io
+      - orders.acme.cert-manager.io
+      - challenges.acme.cert-manager.io
     # Use file-level backup for all PVCs (via Kopia)
     defaultVolumesToFsBackup: true
     # 30-day retention


### PR DESCRIPTION
## What

Adds cert-manager's ephemeral runtime resources to the nightly backup `excludedResources` in `schedule-nightly.yaml`:

- `certificaterequests.cert-manager.io`
- `orders.acme.cert-manager.io`
- `challenges.acme.cert-manager.io`

## Why

On **2026-06-29**, eight apps (`firefly, nextcloud, bookstack, audiobookshelf, memoet, snibox, vikunja, webtrees`) served **expired TLS certificates** and were unreachable.

Root cause: cert-manager's renewals (scheduled `2026-05-29`) were **deadlocked**. Stale `CertificateRequest` objects dated `2026-03-30` — reintroduced by a **Velero DR restore** during the March VPS-loss event — already occupied the next revision name (`<app>-tls-secret-2`). cert-manager couldn't create the renewal request, looped on `"already exists"` for 22+ days (firefly logged 63,928 failed attempts), and the certs silently expired once the 30-day renewal buffer ran out.

These `request`/`order`/`challenge` objects are **regenerable runtime children** of `Certificate`s — backing them up and restoring them re-seeds the exact collisions. Excluding them means a future DR restore lets cert-manager recreate them cleanly.

The `*-tls` **Secrets and `Certificate` objects remain backed up**, so a restore reuses existing cert material (no re-issuance, no Let's Encrypt rate-limit risk).

## Impact

- No effect on normal operation — these objects are transient.
- Future DR restores won't reintroduce the renewal deadlock.
- Addresses the **trigger** only; the **detection** gap (no alerting → a wedged renewal stays invisible for ~30 days) is a separate follow-up (an ntfy cert-expiry alarm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
