### PR TITLE
texas-fold-em: 0.9.2 → 0.9.3 (push resolves source from mirror)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.9.2
+    version: 0.9.3
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Fixes 'push aborted — couldn't resolve source "Ixigo AU Bank Credit Card"' for an asset the user just created (no transaction history). Push-time name→id resolution now falls back to the firefly_accounts mirror. See rounakdatta/texas-fold-em#41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)