### PR TITLE
texas-fold-em: 0.10.0 → 0.10.1 (review UX: foreign amount, firefly link, account sync)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.10.0
+    version: 0.10.1
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Shows the foreign charge amount in the review UI, fixes the firefly deep-link for all pushed rows (persist group id + fetch by group id), and adds an on-demand 'sync accounts from firefly' button + mirror-backed autocompletes. See rounakdatta/texas-fold-em#43.