### PR TITLE
texas-fold-em: 0.10.4 → 0.10.5 (transfer asset-twin remap)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.10.4
+    version: 0.10.5
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Bill-payment transfers whose destination resolved to a duplicate expense account now remap to the asset twin, fixing the 422. See rounakdatta/texas-fold-em#47.