### PR TITLE
texas-fold-em: 0.11.1 → 0.11.2 (honor name-only account correction)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.11.1
+    version: 0.11.2
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Correcting a destination to a new account now takes effect on push/update (was falling back to the stale proposed id). See rounakdatta/texas-fold-em#50.