### PR TITLE
texas-fold-em: 0.11.2 → 0.11.3 (list shows firefly's actual account)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.11.2
+    version: 0.11.3
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Fixes the list showing a corrected transaction's stale account instead of firefly's actual one. See rounakdatta/texas-fold-em#51.