### PR TITLE
texas-fold-em: 0.11.4 -> 0.12.0 (timezone-aware meal inference)

### DIFF
--- a/kubernetes/apps/texas-fold-em/kustomization.yaml
+++ b/kubernetes/apps/texas-fold-em/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: texas-fold-em
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.11.4
+    version: 0.12.0
     releaseName: texas-fold-em
     namespace: apps
     valuesFile: values.yaml


### PR DESCRIPTION
Classifier now infers the local timezone from a foreign charge's currency so meal/occasion is judged in local time (not the server IST). See rounakdatta/texas-fold-em#53.