### PR TITLE
storage: make reclaimPolicy Retain an enforced invariant; pin k3s node name

### DIFF
--- a/.github/workflows/deploy-stuff.yml
+++ b/.github/workflows/deploy-stuff.yml
@@ -58,6 +58,79 @@ jobs:
         with:
           kustomize-version: "5.4.3"
 
+      # Data-safety invariant: every PV must be reclaimPolicy Retain, so that
+      # deleting a stale PVC/PV object never erases the backing directory under
+      # /var/lib/rancher/k3s/storage.
+      #
+      # k3s ships local-path-provisioner with a `local-path` StorageClass whose
+      # reclaimPolicy is Delete, and PVs inherit it at creation. Recovering from
+      # a control-plane rename requires deleting PV objects (nodeAffinity is
+      # immutable), which with Delete would erase the data instead of relocating
+      # it -- ~52GB, during the 2026-07-29 outage.
+      #
+      # Runs before the apply so the class is already Retain by the time this
+      # deploy provisions any new PVC, and repairs drift on existing PVs: the
+      # class is owned by k3s's Addon controller, which re-applies its bundled
+      # local-storage.yaml (Delete) on every k3s restart. Residual window: a PVC
+      # first bound between a k3s restart and this step can be born Delete; the
+      # next deploy repairs it. New PVCs only appear when an app is added, which
+      # goes through this workflow anyway. Idempotent, and fails closed.
+      - name: Enforce reclaimPolicy Retain on all volumes
+        run: |
+          set -euo pipefail
+
+          # StorageClass, so newly provisioned PVs are born Retain. reclaimPolicy
+          # is immutable ("updates to reclaimPolicy are forbidden"), so the class
+          # has to be recreated rather than patched -- which is also why it is
+          # deliberately not a kustomize resource. Deleting a StorageClass
+          # touches no PVs and no data. Values are read from the live object so a
+          # k3s upgrade changing the provisioner/binding mode is carried over.
+          sc_policy=$(kubectl get sc local-path -o jsonpath='{.reclaimPolicy}' 2>/dev/null || true)
+          if [ -z "$sc_policy" ]; then
+            echo "ERROR: StorageClass 'local-path' not found -- k3s ships it, so" >&2
+            echo "       something is wrong with the cluster. Not proceeding." >&2
+            exit 1
+          fi
+          if [ "$sc_policy" != "Retain" ]; then
+            kubectl get sc local-path -o json \
+              | jq '.reclaimPolicy = "Retain"
+                    | del(.metadata.uid, .metadata.resourceVersion,
+                          .metadata.creationTimestamp, .metadata.managedFields,
+                          .metadata.generation,
+                          .metadata.annotations["objectset.rio.cattle.io/applied"])' \
+              > /tmp/local-path-retain.json
+            kubectl delete sc local-path
+            kubectl create -f /tmp/local-path-retain.json
+            echo "StorageClass local-path recreated with Retain."
+          fi
+
+          # Existing PVs. This is the load-bearing guarantee: a PV marked Retain
+          # keeps its data no matter what happens to the PVC or the class.
+          kubectl get pv \
+            -o custom-columns='N:.metadata.name,P:.spec.persistentVolumeReclaimPolicy' \
+            --no-headers | awk '$2!="Retain"{print $1}' | while read -r pv; do
+              kubectl patch pv "$pv" \
+                -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}' >/dev/null
+              echo "patched -> Retain: $pv"
+            done
+
+          kubectl get pv -o custom-columns='P:.spec.persistentVolumeReclaimPolicy' \
+            --no-headers | sort | uniq -c
+
+          # Fail closed -- this is a safety invariant, not best-effort cleanup.
+          # Counted with awk rather than `grep -qv Retain`: exit statuses for -q
+          # combined with -v are not consistent across grep implementations
+          # (ugrep 7.5 returns 1 even when non-matching lines are selected), and
+          # a guard that silently passes depending on the installed grep is
+          # worse than no guard at all.
+          remaining=$(kubectl get pv \
+            -o custom-columns='P:.spec.persistentVolumeReclaimPolicy' \
+            --no-headers | awk '$1!="Retain"{c++} END{print c+0}')
+          if [ "$remaining" != "0" ]; then
+            echo "ERROR: $remaining PV(s) are not Retain." >&2
+            exit 1
+          fi
+
       - name: Deploy manifests
         run: |
           # Render once (helm fetches the chart over network)

--- a/ansible/roles/k3s/defaults/main.yml
+++ b/ansible/roles/k3s/defaults/main.yml
@@ -1,0 +1,40 @@
+---
+# k3s node name for the control plane.
+#
+# WARNING: DO NOT CHANGE THIS VALUE once the cluster holds data.
+#
+# Every local-path PV hard-pins `spec.nodeAffinity` to
+# `kubernetes.io/hostname: <this value>`, and that field is IMMUTABLE. Changing
+# it orphans every PV, makes all stateful pods unschedulable, and takes the whole
+# homelab down with 5xx -- which is exactly what happened on 2026-07-29 when the
+# control-plane host was rebuilt and its hostname changed `rounak` -> `vizerizz`.
+#
+# Pinning `--node-name` decouples the k3s node identity from the OS hostname, so
+# a future rebuild/rename of the host no longer orphans the volumes. That is why
+# this is a fixed literal and deliberately NOT `inventory_hostname` or
+# `ansible_hostname` -- deriving it from the host would reintroduce the bug.
+#
+# If it ever must change, every local-path PV has to be repointed in the same
+# change, because nodeAffinity cannot be patched. For each PV pinned to the old
+# name (kubectl get pv -o json | look at
+# spec.nodeAffinity.required.nodeSelectorTerms[].matchExpressions[].values):
+#
+#   1. kubectl patch pv <pv> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+#      ^ do this for ALL of them FIRST. With the inherited Delete policy, step 2
+#        erases the data instead of relocating it.
+#   2. Dump the spec, set nodeAffinity to the new hostname, and drop
+#      metadata.{uid,resourceVersion,creationTimestamp,finalizers,managedFields}
+#      and status -- but KEEP claimRef (including uid), capacity, accessModes and
+#      local.path, or the PVC rebinds to a fresh empty volume instead of the data.
+#   3. kubectl delete pv <pv> --wait=false, then clear the finalizer
+#      (kubectl patch pv <pv> -p '{"metadata":{"finalizers":null}}' --type=merge)
+#      since a bound PV holds kubernetes.io/pv-protection and won't delete.
+#   4. kubectl apply the rewritten spec; the PVC rebinds to the same directory.
+#   5. Pods stranded on the old node sit in Terminating forever (its kubelet is
+#      gone): kubectl delete pod <p> -n <ns> --force --grace-period=0
+#
+# Do NOT delete the old Node object: it can share an etcd member name with the
+# live one (annotation etcd.k3s.cattle.io/node-name), and k3s maps Node -> etcd
+# member through that, so deleting it can remove the only live etcd member and
+# destroy the cluster. Check before assuming otherwise.
+k3s_control_node_name: vizerizz

--- a/ansible/roles/k3s/tasks/main.yml
+++ b/ansible/roles/k3s/tasks/main.yml
@@ -8,10 +8,16 @@
     path: /usr/local/bin/k3s
   register: k3s_binary
 
+# --node-name pins the k3s node identity so it no longer follows the OS hostname.
+# Without it, a host rebuild/rename registers a brand-new node and orphans every
+# local-path PV (immutable nodeAffinity) -- the 2026-07-29 outage. Note this only
+# takes effect on a fresh install (see the `when` below); the running cluster is
+# untouched. Read roles/k3s/defaults/main.yml before changing the value.
 - name: Install K3s with Tailscale configuration
   ansible.builtin.shell: |
     curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server \
       --cluster-init \
+      --node-name={{ k3s_control_node_name }} \
       --node-ip={{ host_tailscale_ip }} \
       --bind-address={{ host_tailscale_ip }} \
       --advertise-address={{ host_tailscale_ip }} \
@@ -42,6 +48,12 @@
   retries: 5
   delay: 10
   until: k3s_ready.rc == 0
+
+# Note: reclaimPolicy Retain is enforced in .github/workflows/deploy-stuff.yml
+# rather than here. A k3s restart resets the local-path StorageClass to Delete,
+# but PVs are only ever created when an app is added, which goes through that
+# workflow -- so the deploy-time check is where it actually matters, and keeping
+# a single copy avoids two safety-critical implementations drifting apart.
 
 - name: Fetch kubeconfig file
   ansible.builtin.fetch:

--- a/kubernetes/apps/memoet/deployment.yaml
+++ b/kubernetes/apps/memoet/deployment.yaml
@@ -21,6 +21,15 @@ spec:
       labels:
         app: memoet
     spec:
+      # Co-locate with postgres (which runs on the control-plane node, pinned
+      # there by its local-path PVC). memoet is the only app here with no PVC
+      # of its own, so nothing otherwise stops the scheduler putting it on the
+      # rishra worker — that link is ~200ms RTT, and Ecto's pool gives up with
+      # `queue_timeout` mid-migration long before a connection is established.
+      # Selecting on the role label rather than a hostname keeps this correct
+      # across control-plane rebuilds/renames.
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
       containers:
       - name: memoet
         image: rounakdatta/memoet:latest

--- a/kubernetes/infrastructure/velero/schedule-nightly.yaml
+++ b/kubernetes/infrastructure/velero/schedule-nightly.yaml
@@ -33,8 +33,14 @@ spec:
       - challenges.acme.cert-manager.io
     # Use file-level backup for all PVCs (via Kopia)
     defaultVolumesToFsBackup: true
-    # 30-day retention
-    ttl: 720h
+    # 90-day retention. Widened from 30d (720h) after the 2026-07-29 outage: the
+    # cluster was down ~23h before anyone noticed, and a 30-day window leaves
+    # little room to reach back past a problem that went unspotted for a while.
+    # A TTL is kept rather than dropped so R2 storage stays bounded -- expiry is
+    # the one deliberate exception to the "never auto-delete data" invariant
+    # enforced in .github/workflows/deploy-stuff.yml, because unbounded backup
+    # growth has a real cost.
+    ttl: 2160h
     # Use the default (R2) storage location
     storageLocation: default
     # Include cluster-scoped resources (ClusterIssuers, etc.)


### PR DESCRIPTION
## Why

On **2026-07-29** the control-plane host was rebuilt (AlmaLinux 9.7 → 9.8) and its hostname changed `rounak` → `vizerizz`. k3s registered a **new** node, orphaning all 21 `local-path` PVs — they hard-pin `spec.nodeAffinity` to `kubernetes.io/hostname`, and that field is **immutable**.

Every stateful pod went `Pending` behind a wedged `Terminating` pod. Traefik stayed up, so it served `503` for dead backends and `500` for routes whose forward-auth middleware couldn't reach `tinyauth`. `ntfy` was the only survivor — its PVC lives on `jomjom`.

Recovery required deleting and recreating the PV objects. With `reclaimPolicy: Delete` inherited from k3s's `local-path` StorageClass, **that would have erased ~52 GB of live data.** Hence this PR.

## The invariant

Data is never auto-deleted, so deleting a stale Kubernetes object is always safe. The deploy workflow reconciles the StorageClass and every PV to `Retain` before `kubectl apply`.

- The **StorageClass** matters so new PVs are *born* `Retain`; the **per-PV policy** is the load-bearing guarantee and repairs drift.
- Drift is expected: the class is owned by k3s's **Addon controller** (`objectset.rio.cattle.io/owner-name=local-storage`), which re-applies `local-storage.yaml` with `Delete` on every k3s restart. So this is a reconciler, not a one-shot fix.
- Both `StorageClass.reclaimPolicy` and `PV.spec.nodeAffinity` are immutable (verified by server-side dry-run: `updates to reclaimPolicy are forbidden`), so the class is deleted and recreated rather than patched. That's also why it is intentionally **not** a kustomize resource — a plain apply would fail and break every deploy.
- **Fails closed**, and the non-Retain count uses `awk`, not `grep -qv Retain`.

> The `grep` detail is not cosmetic. Exit statuses for `-q` combined with `-v` are **not consistent across implementations** — ugrep 7.5 returns 1 even when non-matching lines are selected, so the guard silently passed. GNU grep on `ubuntu-latest` behaves correctly, so CI would have worked, but a safety check whose behaviour depends on the installed `grep` is worse than no check. Caught by testing the guard against synthetic input rather than assuming.

> **Residual window, stated plainly:** a PVC first bound between a k3s restart and the next deploy can still be born `Delete`; the next deploy repairs it. New PVCs only appear when an app is added, which goes through this workflow anyway — so enforcement lives in **one** place rather than duplicating safety-critical logic into the Ansible role where the two copies could drift.

## Prevention

`--node-name` is pinned (`roles/k3s/defaults/main.yml`, default `vizerizz`) so the k3s node identity stops following the OS hostname. **Inert on the running cluster** — the install task is gated on `when: not k3s_binary.stat.exists`. The value must not change, and the file says so loudly.

The recovery procedure for an orphaned-PV outage is documented alongside it, including the ordering that matters (flip **all** PVs to `Retain` *before* deleting any) and preserving `claimRef`/`capacity`/`local.path` so PVCs rebind to the same data instead of a fresh empty volume.

⚠️ It also records that the stale Node object **must not be deleted**: `rounak` and `vizerizz` share `etcd.k3s.cattle.io/node-name=rounak-a174bcca`, and k3s maps Node → etcd member through that annotation, so `kubectl delete node rounak` could remove the only live etcd member and destroy the cluster.

## Two unrelated fixes found while debugging

- **memoet** is the only app deployment with **no PVC**, so nothing anchored it and the scheduler put it on the rishra worker — **212 ms** RTT from postgres vs **0.111 ms** node-local. Ecto's pool can't establish a connection in that budget and dies mid-migration with `queue_timeout`. Pinned to the control plane via the **role label** rather than a hostname, so it survives future renames. (I first suspected flannel VXLAN and then MTU — both wrong; cross-node networking, DNS, credentials, DDL and a 200 KB payload all tested clean.)
- **Velero TTL 720h → 2160h.** The cluster was down ~23h before it was noticed; 30 days leaves little room to reach past a problem that went unspotted. A TTL is kept, not dropped, so R2 storage stays bounded — expiry is the one deliberate exception to the invariant, because unbounded backup growth has real cost. Already applied live too, so code and cluster agree.

## Verification

Enforcement was exercised against the real cluster, not just linted:

| Case | Result |
|---|---|
| Already compliant | no-op, exit 0, `27 Retain` |
| StorageClass broken to `Delete` | recreated as `Retain`; provisioner, binding mode and default-class annotation preserved |
| A PV broken to `Delete` | patched back to `Retain`, PV stayed `Bound`, `tinyauth.db` intact at 53248 bytes |
| Fail-closed guard | counts 1 non-Retain → exits 1; 0 → passes |
| Missing StorageClass | fails with an explicit message instead of a cryptic `jq` error |

`ansible-playbook --syntax-check` passes; all changed YAML parses. Live cluster: **27/27 PVs `Retain`**, StorageClass `Retain`, **zero unhealthy pods**, no 5xx.

⚠️ Rebased onto current `main`, so the cert-manager `excludedResources` work in `schedule-nightly.yaml` is preserved — only the `ttl` block changed.

### Note on scope
No files were added under `.github/scripts/`. `migrate-selectors.py` is untouched — it pre-exists and is invoked at `deploy-stuff.yml:80`, so the directory itself has to stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)