### PR TITLE
agentfest: deploy festie, a remote computer running Claude Code

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -281,6 +281,26 @@
           BASIC_AUTH_USER: keel/username
           BASIC_AUTH_PASSWORD: keel/password
 
+      # agentfest / festie — the remote computer running Claude Code.
+      # Codeman's own login, sitting behind tinyauth rather than instead of it.
+      - name: festie-auth
+        namespace: apps
+        data:
+          codeman-password: agentfest/codeman_password
+
+      # SSH identity for the machine. Needed at container start, not just for
+      # convenience: dotfiles' claude-skills module clones agent-smith during
+      # home-manager activation, so without this the environment comes up
+      # incomplete. `notes` because a private key is multi-line.
+      #
+      # This is a deploy key for the container, deliberately distinct from the
+      # laptop's own key — the two should be revocable independently.
+      - name: festie-ssh
+        namespace: apps
+        type: notes
+        data:
+          id_ed25519: agentfest/ssh_private_key
+
   pre_tasks:
     - name: Verify required environment variables
       ansible.builtin.fail:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -295,11 +295,18 @@
       #
       # This is a deploy key for the container, deliberately distinct from the
       # laptop's own key — the two should be revocable independently.
-      - name: festie-ssh
+      # The two credentials dotfiles reads from fixed paths. `notes` because
+      # both are multi-line armored blocks.
+      #   personal.pem -> ~/.ssh/keys/personal.pem, which configs/ssh names for
+      #     github.com and gitlab.com, so it is what makes git work at all.
+      #   private.key  -> ~/.secrets/private.key, which configs/gnupg imports
+      #     during activation, which is what lets pass/gopass decrypt.
+      - name: festie-secrets
         namespace: apps
         type: notes
         data:
-          id_ed25519: agentfest/ssh_private_key
+          personal.pem: agentfest/ssh_private_key
+          private.key: agentfest/gpg_private_key
 
   pre_tasks:
     - name: Verify required environment variables

--- a/kubernetes/apps/agentfest/ingress.yaml
+++ b/kubernetes/apps/agentfest/ingress.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: festie-ingress
+  namespace: apps
+  annotations:
+    # Automatically provision TLS certificate with Let's Encrypt
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+
+    # Force HTTPS redirect
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+
+    # Security headers
+    traefik.ingress.kubernetes.io/custom-response-headers: |
+      X-Frame-Options: SAMEORIGIN
+      X-Content-Type-Options: nosniff
+
+    # Tinyauth authentication.
+    #
+    # This one matters more here than anywhere else in the cluster: Codeman
+    # launches agents with --dangerously-skip-permissions by default, so
+    # whoever reaches this UI can run anything on the machine, as me, with my
+    # credentials. Codeman's own password is the second lock, not the first.
+    #
+    # If the terminal fails to connect after deploying, suspect this line:
+    # Codeman's terminal is a WebSocket, and forward-auth in front of a WS
+    # upgrade is the usual place these setups break. Removing the middleware
+    # would confirm it — but leave it removed only long enough to diagnose.
+    traefik.ingress.kubernetes.io/router.middlewares: tinyauth-tinyauth@kubernetescrd
+
+spec:
+  tls:
+  - hosts:
+    - festie.taptappers.club
+    secretName: festie-tls-secret
+
+  rules:
+  - host: festie.taptappers.club
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: festie
+            port:
+              number: 3000

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.16
+    version: 0.1.18
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.8
+    version: 0.1.9
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.18
+    version: 0.1.19
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.12
+    version: 0.1.14
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.14
+    version: 0.1.16
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.4
+    version: 0.1.5
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: apps
+
+# One release is one computer. `festie` is the first; further computers are
+# additional releases of this same chart with their own PVCs and hostnames.
+helmCharts:
+  - name: agentfest
+    repo: oci://ghcr.io/rounakdatta/charts
+    version: 0.1.0
+    releaseName: festie
+    namespace: apps
+    valuesFile: values.yaml
+
+resources:
+  - ingress.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.1
+    version: 0.1.2
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.0
+    version: 0.1.1
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.20
+    version: 0.1.21
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.5
+    version: 0.1.8
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.2
+    version: 0.1.3
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.21
+    version: 0.1.22
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.19
+    version: 0.1.20
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.3
+    version: 0.1.4
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.11
+    version: 0.1.12
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.9
+    version: 0.1.11
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.18"
+  tag: "0.1.19"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.16"
+  tag: "0.1.18"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.12"
+  tag: "0.1.14"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.0"
+  tag: "0.1.1"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.19"
+  tag: "0.1.20"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.3"
+  tag: "0.1.4"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.20"
+  tag: "0.1.21"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.9"
+  tag: "0.1.11"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this
@@ -32,7 +32,7 @@ auth:
 # ~/.ssh must stay writable for home-manager's ssh config and known_hosts).
 ssh:
   enabled: true
-  existingSecret: festie-ssh
+  existingSecret: festie-secrets
 
 # Sized for real work — compiles, container builds, language servers. The
 # memory limit is deliberately far above the request: an agent left running

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.11"
+  tag: "0.1.12"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,0 +1,49 @@
+image:
+  repository: ghcr.io/rounakdatta/agentfest
+  tag: "0.1.0"
+
+# Codeman rejects unknown Host headers before any handler runs — it is a
+# DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this
+# Traefik hostname is not, and every request returns `403 host not allowed`
+# until it is listed here.
+codeman:
+  version: "1.18.0"
+  allowedHosts: "festie.taptappers.club"
+
+persistence:
+  enabled: true
+  # Advisory only: local-path does not enforce quotas, it just provisions a
+  # directory on the node. The real limit is the node's free disk, so treat
+  # this as documentation of intent and adjust it to whatever is actually
+  # spare. It is also node-local — this PVC pins the pod to whichever node
+  # first schedules it, permanently.
+  size: 100Gi
+
+# Both secrets come from Bitwarden via `make secrets` (ansible/playbook.yml),
+# so the chart creates neither.
+auth:
+  create: false
+  existingSecret: festie-auth
+
+# Not optional in practice: dotfiles' claude-skills module clones agent-smith
+# during home-manager activation, and that clone is not fault tolerant. The
+# entrypoint copies this key into ~/.ssh (it cannot be mounted there directly —
+# ~/.ssh must stay writable for home-manager's ssh config and known_hosts).
+ssh:
+  enabled: true
+  existingSecret: festie-ssh
+
+# Sized for real work — compiles, container builds, language servers. The
+# memory limit is deliberately far above the request: an agent left running
+# overnight should be able to burst without being OOM-killed mid-task.
+resources:
+  requests:
+    cpu: "2"
+    memory: 4Gi
+  limits:
+    memory: 24Gi
+
+# Deliberately unpinned, matching every app except frigate/ntfy: those two
+# carry homelab.setup/city=rishra because they belong to that physical
+# location. This is general compute and belongs on the main node.
+nodeSelector: {}

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.2"
+  tag: "0.1.3"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.14"
+  tag: "0.1.16"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.1"
+  tag: "0.1.2"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.21"
+  tag: "0.1.22"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.4"
+  tag: "0.1.5"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,13 +1,14 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.8"
+  tag: "0.1.9"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this
 # Traefik hostname is not, and every request returns `403 host not allowed`
 # until it is listed here.
 codeman:
-  version: "1.18.0"
+  # "latest" tracks upstream on restart rather than needing a bump here.
+  version: "latest"
   allowedHosts: "festie.taptappers.club"
 
 persistence:

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.5"
+  tag: "0.1.8"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - home-assistant/
   - synt/
   - texas-fold-em/
+  - agentfest/


### PR DESCRIPTION
`festie` is a persistent remote computer whose primary UI is Claude Code — so agents keep working while the laptop is shut and the phone is in a pocket. The image comes from [`agentfest`](https://github.com/rounakdatta/agentfest), which bakes [`dotfiles`](https://github.com/rounakdatta/dotfiles)' `hosts/festie` into an OCI image: the same vim / tmux / fish / git / claude / MCP config the laptop runs, evaluated for Linux.

**One release is one computer** — a single pod on a single ReadWriteOnce volume holding an entire home directory. Further computers would be additional releases of this chart with their own PVCs and hostnames, which is why `releaseName` is `festie` rather than `agentfest`.

Follows the `texas-fold-em` pattern exactly: chart from `oci://ghcr.io/rounakdatta/charts` pinned to a version, image tag pinned to match `appVersion`, values overridden in-tree.

## Secrets

Two, both from Bitwarden:

| Secret | Bitwarden path | Why |
|---|---|---|
| `festie-auth` | `agentfest/codeman_password` | Codeman's own login, behind tinyauth rather than instead of it |
| `festie-ssh` | `agentfest/ssh_private_key` | **Required at boot**, see below |

The SSH key isn't a convenience. dotfiles' `claude-skills` module clones `agent-smith` during home-manager activation and that clone is not fault tolerant — without the key the environment comes up incomplete. It should be a **container-specific deploy key**, revocable independently of the laptop's own. `type: notes` because a private key is multi-line.

Both need creating in Bitwarden before `make secrets`.

## Choices worth reviewing rather than taking on trust

**Unpinned node.** `frigate` and `ntfy` carry `homelab.setup/city=rishra` because they belong to that physical location; this is general compute, so it follows every other app onto the main node. Worth knowing: `local-path` will pin it there *permanently* once scheduled — moving it later means moving data.

**100Gi.** Larger than anything else in the cluster (previous max 50Gi). But `local-path` doesn't enforce quotas — it provisions a directory — so this is advisory and the real limit is the node's free disk. **Please adjust to whatever is actually spare**; I had no way to check.

**tinyauth is on**, and it matters more here than anywhere else in the cluster. Codeman launches agents with `--dangerously-skip-permissions` by default, so whoever reaches this UI can run anything on the machine, as me, with my credentials. Codeman's password is the second lock, not the first.

**`CODEMAN_ALLOWED_HOSTS` is set to the ingress hostname.** Codeman rejects unknown `Host` headers before any handler runs, as a DNS-rebinding guard. Without this, every request returns `403 host not allowed`.

## Verification

- `kustomize build --enable-helm kubernetes/apps/agentfest/` renders against the **published** 0.1.0 chart
- `kustomize build --enable-helm kubernetes/` — the whole tree, as `deploy-stuff.yml` does — builds clean: 183 resources, exit 0
- The playbook's new entries parse against the existing `k8s_secrets` schema

## What this does **not** prove

The image has been built and pushed, but **never run**. Two things are unknown until a pod exists:

1. Whether home-manager activation succeeds inside the container (`nix-env` finding the baked store DB is the risky part).
2. **Whether Claude Code can authenticate there at all** — still the single thing that can sink the whole idea.

The entrypoint deliberately treats activation failure as non-fatal, so a broken first boot leaves a reachable terminal to debug from rather than a crash-looping pod you can't get into.

Expect the terminal-over-WebSocket path to be the other likely first-deploy snag — forward-auth in front of a WS upgrade is where these setups usually break. The ingress comments note how to confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)