### PR TITLE
agentfest: 0.1.22 -> 0.1.24

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.22
+    version: 0.1.24
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.22"
+  tag: "0.1.24"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this


### PR DESCRIPTION
⚠️ **Merging this restarts the festie pod** (`strategy: Recreate` on a ReadWriteOnce volume), ending any Claude Code session or agent inside it.

Two image bumps in one. `0.1.23` was deployed from this branch before `main` caught up, so merging this both reconciles `main` with the cluster and rolls forward in a single step.

## 0.1.23 — the machine had stopped converging

home-manager concatenates every activation block into one bash script, so `configs/mic`'s `exit 0` on its *"already installed"* path ended the whole run. `linkGeneration` and everything after it never executed — and it exited `0`, so the entrypoint's failure warning never fired.

Because the Nix store lives in the image layer while `$HOME` lives on the PVC, every home-manager symlink in the container ended up pointing into a store path the running image no longer carried: no `~/.claude/settings.json`, stock tmux, a gpg-agent with no pinentry (so `pass` and every pass-backed MCP server were dead), and no `commit.gpgsign` — meaning commits from festie were silently unsigned.

Also in `0.1.23`: `ncurses` so `clear` and terminfo exist at all; project-local MCP directories created rather than skipped; Codeman's linked cases declared rather than clicked; and git transport moved onto the mounted SSH key so pushes stop depending on a manual GPG unlock.

## 0.1.24 — make convergence checkable

`festie-doctor` answers "did this pod converge?" in one command. That matters because the entrypoint deliberately continues past a failed activation so the terminal stays reachable — a running pod proves nothing on its own.

`festie-unlock` primes the gpg agent, whose cache lives in process memory and so dies with the pod on every deploy. It caches sign and decrypt separately, so unlocking for a commit leaves `pass` and the MCP servers locked with no error until one quietly fails to start.

## Verification

Rendered with the same command `deploy-stuff.yml` uses, against the real chart pulled from GHCR. Diff against what the cluster runs today is **exactly 7 lines**:

```
3 x  helm.sh/chart: agentfest-0.1.23 -> 0.1.24
3 x  app.kubernetes.io/version: 0.1.23 -> 0.1.24
1 x  image: ghcr.io/rounakdatta/agentfest:0.1.23 -> 0.1.24
```

No selector change (`migrate-selectors.py` is a no-op), no PVC spec change, `helm.sh/resource-policy: keep` intact, no Ingress change. Chart `0.1.24` and image `0.1.24` both confirmed present in GHCR.

## After the rollout

```bash
festie-doctor     # ships in 0.1.24, so it is on PATH
```

Expect 17 PASS and 2 FAIL: signing and decryption report locked, because the passphrase cache dies with the pod. That is correct, not a regression — `festie-unlock` clears both, and must be run before starting a session in `~/personal` or `~/work` if the pass-backed MCP servers are wanted.