### PR TITLE
agentfest: 0.1.24 -> 0.1.25, drop Codeman's Basic auth

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.24
+    version: 0.1.25
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.24"
+  tag: "0.1.25"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this
@@ -20,9 +20,25 @@ persistence:
   # first schedules it, permanently.
   size: 100Gi
 
-# Both secrets come from Bitwarden via `make secrets` (ansible/playbook.yml),
-# so the chart creates neither.
+# Codeman's own Basic auth is OFF here, so tinyauth (Google OAuth + the email
+# whitelist) is the only thing between the internet and a shell on this box.
+# That is a deliberate reduction, not an oversight — the chart's values.yaml
+# carries the full reasoning. The short version: Codeman only implements HTTP
+# Basic, and its hardcoded brute-force limiter is hostile behind an ingress,
+# because it builds Fastify without trustProxy so every device shares one bucket
+# of ten failures. The 429 it returns carries no WWW-Authenticate header, so the
+# browser stops offering the password dialog and the correct password can no
+# longer be presented at all.
+#
+# Worth re-reading before the next hostname change: festie.taptappers.club
+# resolves to a PUBLIC IP (cert-manager's HTTP-01 solver needs port 80
+# reachable), so "it's on the tailnet" is not a layer here.
+#
+# existingSecret is left pointing at festie-auth on purpose. The secret still
+# syncs from Bitwarden and is simply unused, which makes flipping this back a
+# one-line change rather than a secrets round-trip.
 auth:
+  enabled: false
   create: false
   existingSecret: festie-auth
 


### PR DESCRIPTION
⚠️ **Merging this restarts the festie pod**, ending any session inside it.

Codeman's own password was a second lock behind tinyauth. Behind an authenticating reverse proxy it locked *us* out more reliably than an attacker, so it's off.

## Why

Codeman implements HTTP Basic and nothing else — there is no login route in the codebase — so the credential was a shared static secret in a browser dialog no password manager can fill. Its limiter made that actively hostile:

- `AUTH_FAILURE_MAX` (10) and the 15-minute window are hardcoded, no override.
- The 429 carries **no `WWW-Authenticate` header**, so once it trips the browser stops offering the dialog. The credential check runs *before* the limiter, so the right password would still be accepted — you're just never asked again.
- Fastify is built **without `trustProxy`** and nothing reads `X-Forwarded-For`, so behind Traefik every device shares one bucket of ten. Any credential-less request counts, including the first request of a page load.

## What this means

**tinyauth (Google OAuth + email whitelist) is now the only thing between the internet and a shell on this box.** A real reduction in defence, taken deliberately.

It matters more here than it would elsewhere: `festie.taptappers.club` resolves to a **public IP**, because cert-manager's HTTP-01 solver needs port 80 reachable. There is no tailnet layer, despite what the agentfest README claimed until [agentfest#4](https://github.com/rounakdatta/agentfest/pull/4) rewrote it.

`existingSecret` still points at `festie-auth`. The secret keeps syncing from Bitwarden, simply unused, so flipping this back is a one-line change rather than a secrets round-trip.

## Verification

Rendered with the same command `deploy-stuff.yml` uses, against chart `0.1.25` pulled from GHCR. Full diff vs what the cluster runs today:

```
- CODEMAN_PASSWORD (+ its secretKeyRef to festie-auth)
+ CODEMAN_ALLOW_UNAUTHENTICATED_NETWORK: "1"
  image 0.1.24 -> 0.1.25
  3x chart + version labels
```

`CODEMAN_PASSWORD` occurrences in the render: **0**. Secrets rendered: **0**. No selector change, no PVC change, `resource-policy: keep` intact.