### PR TITLE
agentfest: 0.1.25 -> 0.1.27

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.25
+    version: 0.1.27
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.25"
+  tag: "0.1.27"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this


### PR DESCRIPTION
⚠️ **Merging this restarts the festie pod**, ending any session inside it.

Two image bumps folded into one deploy so the pod restarts once. `0.1.26` was built and tagged but never rolled out.

## 0.1.26 — auto mode as declared config

`/auto-mode-setup` saves into `~/.claude/settings.json`, which in this image is a **read-only symlink into the Nix store**. So the wizard scanned, drafted a proposal, failed to write, and re-offered itself on every new session — which here means after every deploy of this app.

`permissions.defaultMode` moves `bypassPermissions` → `auto`: stricter rather than looser, since bypass runs everything silently while auto puts each action past a classifier that still refuses what `hard_deny` names.

## 0.1.27 — byoc as a case

`~/work/byoc` becomes a Codeman case with its own `.mcp.json`. Sessions start **in** the case directory and resolve skills and MCP servers once at startup, so `cd`-ing after launch picks up neither.

Skills climb ancestors carrying a `CLAUDE.md` while project MCP does not — so linking the case alone would have given it every byoc skill and none of Lyric's servers, `notprod-lyric-deploy` included.

## Verification

Rendered with the same command `deploy-stuff.yml` uses, against chart `0.1.27` pulled from GHCR. Diff vs what the cluster runs today is **exactly 7 lines** — image tag plus 3× chart and version labels. Nothing else.

`CODEMAN_PASSWORD` occurrences: **0**; `CODEMAN_ALLOW_UNAUTHENTICATED_NETWORK=1` still set, so the Basic-auth removal from `0.1.25` is unchanged. No selector, PVC or Ingress change.