### PR TITLE
agentfest: 0.1.27 -> 0.1.28

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.27
+    version: 0.1.28
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.27"
+  tag: "0.1.28"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this


### PR DESCRIPTION
⚠️ **Merging this restarts the festie pod**, ending any session inside it.

Picks up dotfiles `48c9f0e` → `dc90607`, fixing two false alarms in `festie-doctor`.

## Why

The doctor grepped for the literal `"defaultMode":"bypassPermissions"`. When `0.1.26` legitimately changed that to `"auto"`, it reported a broken machine — on a machine that was fine, and whose `settings.json` had already **passed** the symlink check three lines above.

It also hardcoded the case list as `personal` and `work`, so `byoc` shipped in `0.1.27` with no coverage at all.

Both are the same class of bug the doctor exists to catch, and worse in kind: a checker that cries wolf trains you to ignore it, and one that silently skips a case reports all-clear on ground it never looked at.

It now reports whichever permission mode is configured, and derives its case checks from `programs.codeman.linkedCases` so adding a case extends the doctor automatically.

**Diagnostic-only** — no runtime behaviour changes.

## Verification

Rendered with the same command `deploy-stuff.yml` uses, against chart `0.1.28` from GHCR. Diff vs the running cluster is **exactly 7 lines** — image tag plus 3× chart/version labels.

`CODEMAN_PASSWORD` occurrences: **0**, `CODEMAN_ALLOW_UNAUTHENTICATED_NETWORK` present — the Basic-auth removal from `0.1.25` is unchanged. No selector, PVC or Ingress change.

The fixed doctor was run against the live container before this bump: **18/18 pass**, reporting `claude permission mode: auto` and all three cases.