### PR TITLE
agentfest: 0.1.28 -> 0.1.29

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.28
+    version: 0.1.29
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.28"
+  tag: "0.1.29"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this


### PR DESCRIPTION
Picks up dotfiles `dc90607` → `02da4f1` ([dotfiles#95](https://github.com/rounakdatta/dotfiles/pull/95), [agentfest#8](https://github.com/rounakdatta/agentfest/pull/8)), which makes festie's Claude permission mode a property of the configuration instead of a dropdown in Codeman's UI.

Codeman turns its `claudeMode` setting into an explicit CLI flag at spawn (`--dangerously-skip-permissions` / `--permission-mode auto`), and a command-line argument outranks a user settings file. So it silently beat `~/.claude/settings.json`'s `permissions.defaultMode`, and nothing on the Claude side could reveal which mode sessions actually ran in. The value lived only in Codeman's own `settings.json` on the PVC — runtime state no repo recorded.

`programs.codeman.claudePermissionMode` now writes it on every activation, so it survives a pod restart and a fresh volume alike. `configs/claude` derives its own spelling from the same option, and `festie-doctor` fails when the two disagree.

## Runtime behaviour does change

festie moves to `dangerously-skip-permissions`. Sessions started from the UI will no longer run behind the auto-mode classifier. The point of this machine is work that finishes unattended, and a prompt waiting for an answer is the failure mode that costs the whole session.

Defensible because this pod is disposable — one PVC, rebuilt from these repos, Velero behind it. It does mean a Tinyauth bypass now yields an unprompted shell with a GPG key and cluster credentials rather than a classifier-guarded agent. Reverting is a one-word change in `hosts/festie/home.nix`.

Deploy is `make deploy` (`kubectl apply -k kubernetes/`); the Deployment is `strategy: Recreate` on a RWO volume, so the pod is replaced rather than rolled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
