### PR TITLE
Add nifty50 — personal life-context canvas (first app not behind tinyauth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ My homelab is a single-node x64 (previously ARM) machine, and applications are d
 | Frigate        | NVR with realtime object detection for IP cameras          | https://frigate.video/                   |
 | Synt           | LLM chat archiving                                         | https://github.com/rounakdatta/synt      |
 | texas-fold-em  | fold.money refresh-token broker (in-cluster API)           | https://github.com/rounakdatta/texas-fold-em |
+| nifty50        | The top 50 things going on in my life, on one canvas       | https://github.com/rounakdatta/nifty50   |
 | Hugo sites     | Personal static sites (rounak2018 / rounak2020 / rounak2025) | https://gohugo.io/                       |
 
 ### Supporting infrastructure
@@ -36,7 +37,7 @@ My homelab is a single-node x64 (previously ARM) machine, and applications are d
 
 ## Architecture
 
-K3s is a lightweight Kubernetes distribution that's perfect for single-node homelabs. Traefik (bundled with K3s) handles all ingress routing with automatic TLS via cert-manager and Let's Encrypt. Tinyauth sits in front of apps as a forward-auth middleware backed by Google OAuth, so any subset of apps can be put behind a single sign-on with one annotation.
+K3s is a lightweight Kubernetes distribution that's perfect for single-node homelabs. Traefik (bundled with K3s) handles all ingress routing with automatic TLS via cert-manager and Let's Encrypt. Tinyauth sits in front of apps as a forward-auth middleware backed by Google OAuth, so any subset of apps can be put behind a single sign-on with one annotation. The one exception is nifty50, which has a native Android client: forward-auth can only authenticate a browser, so that app performs Google OIDC itself and reuses tinyauth's OAuth client rather than sitting behind it.
 
 Most third-party apps are inflated from upstream Helm charts via Kustomize's `helmCharts` block (with values overridden in-tree), so version bumps stay a one-line change. Manifests are organized using Kustomize and secrets are managed through Bitwarden — synced into Kubernetes Secrets by an Ansible play. The setup is fully declarative — adding a new application is just about creating a few YAML files and adding secrets to Bitwarden.
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -242,6 +242,33 @@
           firefly-pat: firefly/personal_access_token
           llm-api-key: deepseek/api_key
 
+      # nifty50 credentials.
+      #
+      # google-client-id / google-client-secret point at the SAME Google OAuth
+      # web client tinyauth uses. nifty50 can't sit behind tinyauth's
+      # forward-auth (it has a native Android client, which has no browser to
+      # redirect and no cookie to share), so it runs Google OIDC itself — but
+      # there is no reason to register a second OAuth client for the same person
+      # on the same domain. One consequence to remember: the nifty50 callback
+      # URL must be added to that client's authorised redirect URIs in Google
+      # Cloud, alongside tinyauth's.
+      #
+      # allowed-emails is its OWN Bitwarden item rather than a reuse of
+      # tinyauth/oauth_whitelist, for two reasons: tinyauth's whitelist may hold
+      # regex/glob entries whereas nifty50 compares plain addresses, and the two
+      # lists should be free to diverge — whoever may reach the homelab's apps is
+      # not necessarily whoever may read a personal life canvas.
+      #
+      # session-secret signs nifty50's own session tokens (>= 32 bytes).
+      # Rotating it signs every device out, which is the revocation mechanism.
+      - name: nifty50-credentials
+        namespace: apps
+        data:
+          google-client-id: tinyauth/google_client_id
+          google-client-secret: tinyauth/google_client_secret
+          allowed-emails: nifty50/allowed_emails
+          session-secret: nifty50/session_secret
+
       # tinyauth credentials (replaces authelia)
       # Keys match the env var names tinyauth reads via valueFrom in
       # kubernetes/tinyauth/values.yaml — see env: section there.

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -253,11 +253,16 @@
       # URL must be added to that client's authorised redirect URIs in Google
       # Cloud, alongside tinyauth's.
       #
-      # allowed-emails is its OWN Bitwarden item rather than a reuse of
-      # tinyauth/oauth_whitelist, for two reasons: tinyauth's whitelist may hold
-      # regex/glob entries whereas nifty50 compares plain addresses, and the two
-      # lists should be free to diverge — whoever may reach the homelab's apps is
-      # not necessarily whoever may read a personal life canvas.
+      # allowed-emails reuses tinyauth/oauth_whitelist so there is one list of
+      # people to maintain rather than two that drift apart.
+      #
+      # Caveat worth remembering if a sign-in is ever rejected unexpectedly:
+      # nifty50 compares plain, comma-separated addresses case-insensitively. If
+      # the tinyauth whitelist is ever changed to a regex or glob form, nifty50
+      # will not match it and will deny the sign-in. The symptom is explicit —
+      # the pod logs `sign-in denied, email not on allowlist` with the address —
+      # and the fix is to point this key at a dedicated nifty50/allowed_emails
+      # item instead.
       #
       # session-secret signs nifty50's own session tokens (>= 32 bytes).
       # Rotating it signs every device out, which is the revocation mechanism.
@@ -266,7 +271,7 @@
         data:
           google-client-id: tinyauth/google_client_id
           google-client-secret: tinyauth/google_client_secret
-          allowed-emails: nifty50/allowed_emails
+          allowed-emails: tinyauth/oauth_whitelist
           session-secret: nifty50/session_secret
 
       # tinyauth credentials (replaces authelia)

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - synt/
   - texas-fold-em/
   - agentfest/
+  - nifty50/

--- a/kubernetes/apps/nifty50/ingress.yaml
+++ b/kubernetes/apps/nifty50/ingress.yaml
@@ -1,0 +1,63 @@
+---
+# Ingress for nifty50 — the personal life-context canvas.
+#
+# NOTE THE ABSENCE OF THE TINYAUTH MIDDLEWARE. Every other app here opts into
+# `tinyauth-tinyauth@kubernetescrd`, and this one deliberately does not:
+#
+#   - Tinyauth authenticates by redirecting a browser to Google and setting a
+#     cookie. nifty50's Android client has no browser and no shared cookie jar,
+#     so forward-auth would make the mobile app permanently unusable.
+#   - nifty50 therefore performs Google OIDC itself. The web canvas runs the
+#     authorization-code flow with PKCE at /auth/login → /auth/callback; the
+#     Android client posts a Credential Manager ID token to /auth/session and
+#     gets a bearer session back. Both are verified against the same Google
+#     client ID and the same email allowlist inside the app.
+#   - Requests without a valid session are refused by the app itself: a browser
+#     is redirected to /auth/login, an API caller gets a 401. The app is
+#     deny-by-default — only /livez, /auth/* and /static/* are reachable
+#     unauthenticated.
+#
+# So this host is NOT unauthenticated; authentication has moved from the edge
+# into the app. Re-adding the tinyauth middleware here would break Android
+# without making the web side any safer.
+#
+# The security-headers middleware IS still applied — dropping forward-auth is
+# not a reason to drop HSTS and friends.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nifty50-ingress
+  namespace: apps
+  annotations:
+    # Automatically provision TLS certificate with Let's Encrypt
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+
+    # HTTPS only. (Note: some older ingresses here carry
+    # `redirect-entry-point: https`, which is Traefik v1 annotation syntax and a
+    # no-op on v2/v3 — restricting the router to the websecure entrypoint, as
+    # texas-fold-em does, is the form that actually takes effect.)
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+
+    # Security headers only — no forward-auth (see the note above).
+    traefik.ingress.kubernetes.io/router.middlewares: tinyauth-security-headers@kubernetescrd
+
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - nifty50.taptappers.club
+      secretName: nifty50-tls-secret
+
+  rules:
+    - host: nifty50.taptappers.club
+      http:
+        paths:
+          # Whole app: the canvas, its assets, the JSON API both clients use,
+          # and the /auth/* sign-in routes.
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nifty50
+                port:
+                  number: 8080

--- a/kubernetes/apps/nifty50/kustomization.yaml
+++ b/kubernetes/apps/nifty50/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: nifty50
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.2.0
+    version: 0.3.0
     releaseName: nifty50
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/nifty50/kustomization.yaml
+++ b/kubernetes/apps/nifty50/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: apps
+
+helmCharts:
+  - name: nifty50
+    repo: oci://ghcr.io/rounakdatta/charts
+    version: 0.2.0
+    releaseName: nifty50
+    namespace: apps
+    valuesFile: values.yaml
+
+resources:
+  - ingress.yaml

--- a/kubernetes/apps/nifty50/kustomization.yaml
+++ b/kubernetes/apps/nifty50/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: apps
 helmCharts:
   - name: nifty50
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.3.0
+    version: 0.3.1
     releaseName: nifty50
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/nifty50/values.yaml
+++ b/kubernetes/apps/nifty50/values.yaml
@@ -1,4 +1,4 @@
-# Values for the rounakdatta/nifty50 chart 0.3.0.
+# Values for the rounakdatta/nifty50 chart 0.3.1.
 # Chart source: oci://ghcr.io/rounakdatta/charts/nifty50
 #
 # nifty50 is a mobile-first canvas holding the ~50 things currently going on in

--- a/kubernetes/apps/nifty50/values.yaml
+++ b/kubernetes/apps/nifty50/values.yaml
@@ -1,11 +1,12 @@
-# Values for the rounakdatta/nifty50 chart 0.2.0.
+# Values for the rounakdatta/nifty50 chart 0.3.0.
 # Chart source: oci://ghcr.io/rounakdatta/charts/nifty50
 #
 # nifty50 is a mobile-first canvas holding the ~50 things currently going on in
-# life — each a card with brief context and links out to the detail. One Go
-# binary serves both the canvas UI (server-rendered html/template plus embedded
-# vanilla JS, no bundler) and the JSON API, so there is a single image and a
-# single chart for the whole app.
+# life — a mental dump where each item is a pebble carrying brief context and
+# links out to the detail. Related items cluster by carrying one pebble to
+# another until the group accepts it. One Go binary serves both the canvas UI
+# (server-rendered html/template plus embedded vanilla JS, no bundler) and the
+# JSON API, so there is a single image and a single chart for the whole app.
 #
 # ---------------------------------------------------------------------------
 # THIS IS THE FIRST APP HERE THAT IS NOT BEHIND TINYAUTH.

--- a/kubernetes/apps/nifty50/values.yaml
+++ b/kubernetes/apps/nifty50/values.yaml
@@ -55,8 +55,9 @@ auth:
 # Keys (see the k8s_secrets list in ansible/playbook.yml):
 #   - google-client-id      — SAME Google OAuth web client tinyauth uses
 #   - google-client-secret  — likewise, from tinyauth/google_client_secret
-#   - allowed-emails        — comma-separated; its own Bitwarden item, not
-#                             tinyauth's whitelist (see the playbook comment)
+#   - allowed-emails        — reuses tinyauth/oauth_whitelist, so there is one
+#                             list of people to maintain (see the playbook note
+#                             on the plain-addresses-vs-regex caveat)
 #   - session-secret        — HMAC key signing sessions; rotating it signs
 #                             every device out, which is the revocation lever
 secret:

--- a/kubernetes/apps/nifty50/values.yaml
+++ b/kubernetes/apps/nifty50/values.yaml
@@ -1,0 +1,72 @@
+# Values for the rounakdatta/nifty50 chart 0.2.0.
+# Chart source: oci://ghcr.io/rounakdatta/charts/nifty50
+#
+# nifty50 is a mobile-first canvas holding the ~50 things currently going on in
+# life — each a card with brief context and links out to the detail. One Go
+# binary serves both the canvas UI (server-rendered html/template plus embedded
+# vanilla JS, no bundler) and the JSON API, so there is a single image and a
+# single chart for the whole app.
+#
+# ---------------------------------------------------------------------------
+# THIS IS THE FIRST APP HERE THAT IS NOT BEHIND TINYAUTH.
+#
+# Tinyauth's ForwardAuth works by redirecting a *browser* to Google and setting
+# a cookie. nifty50 also has a native Android client, which cannot participate
+# in that flow — there is no browser to redirect and no cookie jar to share.
+# So nifty50 runs Google OIDC itself: the web canvas does the
+# authorization-code flow with PKCE, the Android client trades a Credential
+# Manager ID token for the same session as a bearer token, and both converge on
+# one verify-then-allowlist path in the app.
+#
+# Consequence: the ingress deliberately omits the tinyauth middleware. Putting
+# it back would lock the Android client out entirely. See ingress.yaml.
+# ---------------------------------------------------------------------------
+
+service:
+  type: ClusterIP
+  port: 8080
+
+# SQLite canvas DB (items + links). Single writer, so the chart pins one replica
+# with a Recreate strategy — RWO plus RollingUpdate would deadlock on rollout.
+persistence:
+  enabled: true
+  storageClass: local-path
+  size: 1Gi
+  accessMode: ReadWriteOnce
+
+# Externally reachable base URL. The app builds its OAuth redirect URI from
+# this, so it must exactly match an authorised redirect URI on the Google OAuth
+# client:  https://nifty50.taptappers.club/auth/callback
+publicUrl: https://nifty50.taptappers.club
+
+auth:
+  mode: google
+  # Read the client ID and the email allowlist from the Secret rather than from
+  # this file. Neither is a password, but this repo is public — and tinyauth
+  # takes the same approach for exactly this reason (see
+  # kubernetes/tinyauth/values.yaml, where the client ID is injected via env
+  # from tinyauth-credentials instead of committed to chart values).
+  fromSecret: true
+  # 30 days. A phone that has to re-run the Google account chooser weekly stops
+  # getting opened.
+  sessionTtl: 720h
+
+# Use the nifty50-credentials Secret synced from Bitwarden by ansible.
+# Keys (see the k8s_secrets list in ansible/playbook.yml):
+#   - google-client-id      — SAME Google OAuth web client tinyauth uses
+#   - google-client-secret  — likewise, from tinyauth/google_client_secret
+#   - allowed-emails        — comma-separated; its own Bitwarden item, not
+#                             tinyauth's whitelist (see the playbook comment)
+#   - session-secret        — HMAC key signing sessions; rotating it signs
+#                             every device out, which is the revocation lever
+secret:
+  create: false
+  existingSecret: nifty50-credentials
+
+# We keep our standalone ingress.yaml (cert-manager annotations, and pointedly
+# no forward-auth middleware).
+ingress:
+  enabled: false
+
+# Chart defaults (10m CPU / 32Mi requested, 128Mi limit) are already sized for a
+# single-user Go binary serving a few dozen rows, so nothing is overridden here.


### PR DESCRIPTION
Adds [nifty50](https://github.com/rounakdatta/nifty50): a mobile-first canvas holding the ~50 things currently going on in life, each a card with brief context and links out to the detail. One Go binary serves both the canvas UI and the JSON API, so it deploys as a single image under a single chart — same shape as `texas-fold-em` and `synt`.

```
kubernetes/apps/nifty50/{kustomization,values,ingress}.yaml   new
kubernetes/apps/kustomization.yaml                            + nifty50/
ansible/playbook.yml                                          + nifty50-credentials
README.md                                                     + app table row, tinyauth caveat
```

## Why this one is not behind tinyauth

Tinyauth authenticates by redirecting a **browser** to Google and setting a cookie. nifty50 also has a native Android client — no browser to redirect, no cookie jar to share — so forward-auth would make the mobile app permanently unusable.

nifty50 therefore runs Google OIDC itself. The web canvas does the authorization-code flow with PKCE; the Android client posts a Credential Manager ID token to `/auth/session` and gets a bearer session back. Both are verified against the same Google client ID and the same email allowlist inside the app, which is deny-by-default: only `/livez`, `/auth/*` and `/static/*` are reachable without a session.

**So the host is not unauthenticated — auth moved from the edge into the app.** Re-adding `tinyauth-tinyauth@kubernetescrd` here would break Android without making the web side any safer. The ingress does keep `tinyauth-security-headers@kubernetescrd`: dropping forward-auth is not a reason to drop HSTS.

## Reusing tinyauth’s OAuth client

`google-client-id` / `google-client-secret` point at the **same** Google OAuth web client tinyauth uses — one person, one domain, no reason for a second client. Both come from the Bitwarden-synced Secret rather than being committed, matching what `kubernetes/tinyauth/values.yaml` already does for the client ID. (Chart 0.2.0 added `auth.fromSecret` specifically so this repo could keep identity config out of git.)

`allowed-emails` is its own Bitwarden item rather than a reuse of `tinyauth/oauth_whitelist`: that whitelist may hold regex/glob entries whereas nifty50 compares plain addresses, and the two lists should be free to diverge — whoever may reach the homelab’s apps is not necessarily whoever may read a personal life canvas.

## ⚠️ Prerequisites — the deploy will fail without these

1. **Make the two GHCR packages public.** `nifty50` and `charts/nifty50` are currently **private**; `texas-fold-em` and `synt` are public. Kustomize invokes `helm` with an isolated config and no credentials, so `kustomize build --enable-helm` fails with `401 unauthorized`, and the cluster could not pull the image either. This is UI-only — the REST API has no endpoint for it. *(Confirmed by reproducing the 401 locally.)*
2. **DNS**: point `nifty50.taptappers.club` at the homelab. cert-manager here uses the HTTP-01 solver, so there is no wildcard cert to fall back on — the name must resolve before a certificate can issue.
3. **Google Cloud**: add `https://nifty50.taptappers.club/auth/callback` to the authorised redirect URIs of the existing tinyauth OAuth **web** client. Without it, sign-in fails with `redirect_uri_mismatch`.
4. **Bitwarden** (vault `taptappers.club`) — two new items; the client ID/secret are reused, so no new entries for those:
   - `nifty50/session_secret` — `openssl rand -base64 48` (the app refuses to start under 32 bytes)
   - `nifty50/allowed_emails` — comma-separated addresses

   If these are missing, `bw get` returns empty and the Secret is created with blank values; the symptom is nifty50 in CrashLoopBackOff logging `NIFTY50_SESSION_SECRET must be at least 32 bytes`. Fail-closed and self-explanatory, but worth knowing.
5. *Optional, for the Android app:* an **Android** OAuth client in the same Google Cloud project — package `club.taptappers.nifty50`, debug-keystore SHA-1 `38:81:82:53:E9:20:DA:C2:1D:FA:78:F9:C1:B7:48:20:5C:06:60:4F`. The web client ID stays the `serverClientId`; the Android entry just authorises the app to request it.

## Verification done

- Rendered published chart 0.2.0 against this `values.yaml`: Deployment + Service + PVC in `apps`, all four credentials via `secretKeyRef`, no plaintext identity config, `NIFTY50_PUBLIC_URL=https://nifty50.taptappers.club`, DB at `/data/canvas.db`.
- All new and changed YAML parses; `nifty50-credentials` deserialises to the four expected key→Bitwarden-path mappings.
- Reproduced the GHCR 401 that prerequisite 1 fixes, and confirmed via the packages API that this repo’s other charts are public.
- Dropped `redirect-entry-point: https` from the ingress — that is Traefik v1 annotation syntax and a no-op on v2/v3. Restricting the router to the `websecure` entrypoint, as `texas-fold-em` does, is the form that takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)