### PR TITLE
Add a dispatch-only workflow to bootstrap a missing Bitwarden secret

### DIFF
--- a/.github/workflows/create-bitwarden-secret.yml
+++ b/.github/workflows/create-bitwarden-secret.yml
@@ -1,0 +1,102 @@
+name: Create a missing Bitwarden secret
+
+# Bootstraps a Bitwarden item that a new app needs, for the case the
+# create-missing-bitwarden-secrets-manually skill describes: the item ought to
+# exist but doesn't, because the app is being introduced for the first time.
+#
+# It runs here rather than on a laptop because the Bitwarden API credentials live
+# here as Actions secrets. A password-only login is not a substitute — Bitwarden
+# demands a captcha for password logins from an unrecognised client, which is why
+# `bw login --apikey` is the supported automation path.
+#
+# Deliberate properties:
+#   - Dispatch-only. Nothing about a push should mint credentials.
+#   - Generate-only. There is no input for a literal value, because workflow
+#     inputs are recorded in run metadata — a secret passed in would be visible
+#     there forever. The value is generated in the runner and goes straight to
+#     Bitwarden.
+#   - Idempotent and non-destructive. If the item already exists the run is a
+#     no-op; it never overwrites or deletes, per the skill's standing rule.
+#   - The value is masked and never printed. Verification checks its length.
+
+on:
+  workflow_dispatch:
+    inputs:
+      item_name:
+        description: 'Bitwarden item name, e.g. nifty50/session_secret'
+        required: true
+        type: string
+      bytes:
+        description: 'Random bytes to generate (base64-encoded into the value)'
+        required: false
+        default: '48'
+        type: string
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Bitwarden CLI
+        run: npm install -g @bitwarden/cli
+
+      - name: Create the item if it is missing
+        env:
+          BW_CLIENTID: ${{ secrets.BW_CLIENTID }}
+          BW_CLIENTSECRET: ${{ secrets.BW_CLIENTSECRET }}
+          BW_PASSWORD: ${{ secrets.BW_PASSWORD }}
+          ITEM_NAME: ${{ inputs.item_name }}
+          BYTES: ${{ inputs.bytes }}
+        run: |
+          set -euo pipefail
+
+          bw login --apikey >/dev/null
+          BW_SESSION="$(bw unlock --passwordenv BW_PASSWORD --raw)"
+          export BW_SESSION
+          echo "::add-mask::${BW_SESSION}"
+          bw sync >/dev/null
+
+          if bw get item "${ITEM_NAME}" >/dev/null 2>&1; then
+            echo "✓ ${ITEM_NAME} already exists — nothing to do"
+            bw logout >/dev/null 2>&1 || true
+            exit 0
+          fi
+
+          # Place the new item wherever the existing homelab secrets live, rather
+          # than guessing at an organization id. tinyauth/google_client_id is the
+          # reference because it is known to exist and is read by the deploy.
+          REF="$(bw get item tinyauth/google_client_id)"
+          ORG_ID="$(printf '%s' "$REF" | jq -r '.organizationId // empty')"
+          COLLECTION_IDS="$(printf '%s' "$REF" | jq -c '.collectionIds // []')"
+          if [[ -n "${ORG_ID}" ]]; then
+            echo "Target: organization ${ORG_ID}, $(printf '%s' "$COLLECTION_IDS" | jq 'length') collection(s)"
+          else
+            echo "Target: personal vault (reference item has no organization)"
+          fi
+
+          VALUE="$(openssl rand -base64 "${BYTES}")"
+          echo "::add-mask::${VALUE}"
+
+          if [[ -n "${ORG_ID}" ]]; then
+            PAYLOAD="$(jq -n \
+              --arg name "${ITEM_NAME}" --arg pw "${VALUE}" \
+              --arg org "${ORG_ID}" --argjson cols "${COLLECTION_IDS}" \
+              '{type:1, name:$name, organizationId:$org, collectionIds:$cols,
+                login:{username:null, password:$pw, totp:null}}')"
+          else
+            PAYLOAD="$(jq -n \
+              --arg name "${ITEM_NAME}" --arg pw "${VALUE}" \
+              '{type:1, name:$name, login:{username:null, password:$pw, totp:null}}')"
+          fi
+
+          printf '%s' "${PAYLOAD}" | bw encode | bw create item >/dev/null
+          bw sync >/dev/null
+
+          # Verify by length only — the value itself is never echoed.
+          LEN="$(bw get password "${ITEM_NAME}" | tr -d '\n' | wc -c)"
+          echo "✓ Created ${ITEM_NAME} (${LEN} characters)"
+          if [[ "${LEN}" -lt 32 ]]; then
+            echo "::error::${ITEM_NAME} is shorter than 32 characters, which nifty50 will reject"
+            exit 1
+          fi
+
+          bw logout >/dev/null 2>&1 || true


### PR DESCRIPTION
The `create-missing-bitwarden-secrets-manually` skill describes doing this with the `bw` CLI, but the Bitwarden API credentials only exist here as Actions secrets — so that is where the write has to happen.

A password-only login is not a substitute: Bitwarden demands a captcha for password logins from an unrecognised client, which makes a non-interactive `bw login` hang silently (verified — it produced no output and timed out even with stdin closed). `bw login --apikey` is the supported automation path, and the API key is not stored outside this repo's secrets.

`nifty50/session_secret` is the immediate need, so this generalises the step rather than hand-rolling it once.

### Deliberate properties

- **Dispatch-only.** No push should ever mint a credential.
- **Generate-only.** There is intentionally no input for a literal value: workflow inputs are recorded in run metadata, so a secret passed in would live there permanently. The value is generated in the runner and goes straight to Bitwarden.
- **Idempotent and non-destructive.** An existing item makes the run a no-op. Nothing is overwritten or deleted, per the skill's standing rule.
- **Never printed.** The value and the session key are both `::add-mask::`ed; verification asserts length only.
- **No guessing at org ids.** The new item is placed in whatever organization and collections `tinyauth/google_client_id` already lives in.

Separate from [#145](https://github.com/rounakdatta/homelab.setup/pull/145) on purpose — it is infra tooling, not part of the nifty50 app spec. It also has to land on `main` before it can be dispatched at all, since GitHub only exposes `workflow_dispatch` for workflows present on the default branch.

Note it changes nothing under `kubernetes/**` or `ansible/**`, so merging it does not trigger a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)