### PR TITLE
harden(festie): restrict ingress via NetworkPolicy, pin versions

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -16,3 +16,4 @@ helmCharts:
 
 resources:
   - ingress.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.29
+    version: 0.1.30
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/networkpolicy.yaml
+++ b/kubernetes/apps/agentfest/networkpolicy.yaml
@@ -1,0 +1,61 @@
+---
+# Restrict ingress to festie's HTTP port to the Traefik ingress controller
+# (which runs in kube-system on k3s); no other workload needs to reach it
+# directly.
+#
+# NOTE: k3s must be running its NetworkPolicy controller (the default; disabled
+# only with --disable-network-policy). A policy with no enforcer has no effect,
+# so confirm that before relying on this.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: festie-netpol
+  namespace: apps
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: agentfest
+      app.kubernetes.io/instance: festie
+  policyTypes:
+    - Ingress
+  ingress:
+    # Traefik (kube-system) -> festie:3000.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 3000
+
+# ---------------------------------------------------------------------------
+# Egress is intentionally left at the default (allow-all) for now: this host
+# legitimately reaches many external endpoints, so outbound rules are staged
+# below as ready-to-apply options rather than enabled blind. To use one, pick a
+# tier, uncomment it, AND add "Egress" to policyTypes above.
+#
+# ---- Tier 1: keep the internet open, restrict in-cluster reach ----
+# Leaves internet egress intact while limiting reach to other in-cluster
+# workloads. DNS runs in kube-system, so allow it explicitly.
+#
+#   policyTypes: [Ingress, Egress]
+#   egress:
+#     - to:                                     # DNS
+#         - namespaceSelector:
+#             matchLabels: { kubernetes.io/metadata.name: kube-system }
+#       ports:
+#         - { protocol: UDP, port: 53 }
+#         - { protocol: TCP, port: 53 }
+#     - to:                                     # internet, minus the cluster CIDRs
+#         - ipBlock:
+#             cidr: 0.0.0.0/0
+#             except:
+#               - 10.42.0.0/16                  # k3s pod CIDR
+#               - 10.43.0.0/16                  # k3s service CIDR
+#     # If you still reach specific in-cluster services, add a narrow allow for
+#     # just those instead of opening the whole CIDR.
+#
+# ---- Tier 2: explicit outbound allowlist ----
+# Allow only known egress destinations. More upkeep (CDN IP churn) -- pair with
+# an egress proxy, or resolve/pin the CIDRs actually needed.
+# ---------------------------------------------------------------------------

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -6,9 +6,14 @@ image:
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this
 # Traefik hostname is not, and every request returns `403 host not allowed`
 # until it is listed here.
+# Pin the self-updating components to exact versions rather than tracking
+# "latest", so upgrades are deliberate and reproducible. Bump after reviewing
+# the release notes, then restart the pod.
+claudeCode:
+  version: "2.1.233"
+
 codeman:
-  # "latest" tracks upstream on restart rather than needing a bump here.
-  version: "latest"
+  version: "1.19.3"
   allowedHosts: "festie.taptappers.club"
 
 persistence:

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.29"
+  tag: "0.1.30"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this


### PR DESCRIPTION
## What

Deployment-side hardening for **festie**.

> ⚠️ **Merging this PR deploys** — the `kubernetes/**` path triggers `deploy-stuff` on push to `main`. Left as a **draft** until you choose to roll it out.

| Change |
|--------|
| New `festie-netpol` NetworkPolicy — ingress to `festie:3000` allowed only from Traefik (kube-system) |
| Pin `claudeCode 2.1.233` + `codeman 1.19.3` in the live values (were `latest`) |

### Before merge
**Verify the k3s NetworkPolicy controller is enabled** (default; disabled only with `--disable-network-policy`). A policy with no enforcer has no effect.

### Egress
Left at the default (allow-all). `networkpolicy.yaml` carries two commented, ready-to-apply outbound tiers to enable when you choose.

### Validation
`kustomize build --enable-helm` renders the full overlay (Deployment, Ingress, NetworkPolicy, PVC, Service); `festie-netpol`'s `podSelector` matches the rendered pod labels; the version pins render into the pod env.
