### PR TITLE
codeman: 1.19.3 -> 1.21.0

### DIFF
--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -13,7 +13,7 @@ claudeCode:
   version: "2.1.233"
 
 codeman:
-  version: "1.19.3"
+  version: "1.21.0"
   allowedHosts: "festie.taptappers.club"
 
 persistence:


### PR DESCRIPTION
Automated bump of the pinned `aicodeman` (Codeman) version — the first PR from the new auto-bump workflow.

**1.19.3 → 1.21.0** (8 releases; 1.19.4 → 1.21.0). Changelog: https://www.npmjs.com/package/aicodeman?activeTab=versions

Merging triggers deploy-stuff; the entrypoint installs the new Codeman into the PVC on the next pod restart — **no image rebuild**. This restarts the pod.