### PR TITLE
festie: 0.1.30 -> 0.1.31 (veans, Asia/Kolkata, GPG ownertrust)

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.30
+    version: 0.1.31
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.30"
+  tag: "0.1.31"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this


### PR DESCRIPTION
Picks up [agentfest v0.1.31](https://github.com/rounakdatta/agentfest/releases/tag/v0.1.31) ([agentfest#11](https://github.com/rounakdatta/agentfest/pull/11)), which carries three dotfiles changes ([dotfiles#97](https://github.com/rounakdatta/dotfiles/pull/97)) into the container:

- **veans**, the Vikunja CLI, wrapped so its token comes from `pass`. Paired with the `vikunja-personal-assistant` skill ([agent-smith#3](https://github.com/rounakdatta/agent-smith/pull/3)), this makes a Codeman session the way tasks get filed, instead of the Vikunja web UI.
- **tzdata and an exported `TZ=Asia/Kolkata`.** The container shipped no zoneinfo at all, so `date` answered every `TZ` in UTC *without saying so* — anything scheduled from a shell was 5h30m off.
- **Ultimate ownertrust on our own GPG key** after importing it. `gpg --import` never carries ownertrust, so the keyring could decrypt but not encrypt: `pass show` worked, `pass insert` never did.

## Rollout note

This **restarts festie.** The Deployment is `strategy: Recreate` — the home directory is ReadWriteOnce and single-writer, so the old pod is terminated before the new one starts, and any live agent session on it ends with it.

The new pod also comes up with a locked `gpg-agent`, so the first pass-backed thing to run needs `festie-unlock` in a terminal pane first.