### PR TITLE
itineris: public travel journal at itineris.taptappers.club

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ My homelab is a single-node x64 (previously ARM) machine, and applications are d
 | Synt           | LLM chat archiving                                         | https://github.com/rounakdatta/synt      |
 | texas-fold-em  | fold.money refresh-token broker (in-cluster API)           | https://github.com/rounakdatta/texas-fold-em |
 | Hugo sites     | Personal static sites (rounak2018 / rounak2020 / rounak2025) | https://gohugo.io/                       |
+| itineris       | Travel journal: map, timeline, photo wall, stories (public) | https://github.com/rounakdatta/itineris |
 
 ### Supporting infrastructure
 

--- a/kubernetes/apps/itineris/ingress.yaml
+++ b/kubernetes/apps/itineris/ingress.yaml
@@ -1,0 +1,45 @@
+---
+# PUBLIC on purpose -- there is no tinyauth middleware here, and that is the
+# design, not an omission.
+#
+# itineris is the shareable travel journal: the whole point is that a link can
+# go to anyone, so nothing sits in front of the viewer. The trade is that
+# everything the image serves is world-readable, which is why the public build
+# is expected to be privacy-scrubbed at BUILD time (route starts/ends clipped,
+# home fuzzed, EXIF stripped) rather than hidden at the edge.
+#
+# The upload / admin surface is a separate concern and will get its own
+# ingress behind tinyauth when it exists. Do not "fix" this one by adding the
+# middleware -- that would lock out every person the link was shared with.
+#
+# Mirrors the other public ingresses (audiobookshelf, ntfy): cert-manager TLS
+# on the websecure entrypoint, nothing else.
+#
+# DNS is NOT wildcard on taptappers.club: itineris.taptappers.club needs an A
+# record (Cloudflare, DNS-only like the other hosts) before cert-manager's
+# HTTP-01 challenge can succeed. Until then the pod is healthy and unreachable.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: itineris
+  namespace: apps
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: itineris.taptappers.club
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: itineris
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - itineris.taptappers.club
+    secretName: itineris-tls-secret

--- a/kubernetes/apps/itineris/ingress.yaml
+++ b/kubernetes/apps/itineris/ingress.yaml
@@ -15,9 +15,11 @@
 # Mirrors the other public ingresses (audiobookshelf, ntfy): cert-manager TLS
 # on the websecure entrypoint, nothing else.
 #
-# DNS is NOT wildcard on taptappers.club: itineris.taptappers.club needs an A
-# record (Cloudflare, DNS-only like the other hosts) before cert-manager's
-# HTTP-01 challenge can succeed. Until then the pod is healthy and unreachable.
+# DNS is NOT wildcard on taptappers.club. Records live in the rounakdatta/oh-my-dns
+# repo (records.txt, synced to Cloudflare on push): this host is
+# `A itineris 88.214.24.194`, DNS-only like every other homelab host. Without
+# the record cert-manager's HTTP-01 challenge fails and the pod is healthy but
+# unreachable.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: apps
+
+# Bumping is two lines that move together: `version` here and `image.tag` in
+# values.yaml (the chart would default the image from its appVersion anyway;
+# the explicit pin keeps the deployed image visible in this repo).
+helmCharts:
+  - name: itineris
+    repo: oci://ghcr.io/rounakdatta/charts
+    version: 0.1.0
+    releaseName: itineris
+    namespace: apps
+    valuesFile: values.yaml
+
+resources:
+  - ingress.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -1,0 +1,20 @@
+# Values for the rounakdatta/itineris chart.
+# Chart source: oci://ghcr.io/rounakdatta/charts/itineris
+#
+# itineris is a static travel journal -- map, timeline, photo wall and
+# Instagram-style stories -- served by nginx from an image that IS the site.
+# No state, no database, no secrets: a redeploy is a new image tag, and there
+# is nothing here for Velero to back up.
+
+image:
+  repository: ghcr.io/rounakdatta/itineris
+  # The chart already defaults this to its appVersion, so the pin is redundant
+  # on purpose: it puts the deployed image next to the chart version in
+  # kustomization.yaml, so a bump PR touches both lines together -- the same
+  # convention agentfest follows.
+  tag: "0.1.0"
+
+# Deliberately unpinned, matching every app except frigate/ntfy: those two
+# carry homelab.setup/city=rishra because they belong to that physical
+# location. This is general serving and belongs on the main node.
+nodeSelector: {}

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - synt/
   - texas-fold-em/
   - agentfest/
+  - itineris/


### PR DESCRIPTION
Adds **itineris** — the travel journal (map, timeline, photo wall, Instagram-style stories) — as a chart-based app in `apps`, following the agentfest / texas-fold-em pattern: chart from `oci://ghcr.io/rounakdatta/charts/itineris` (`0.1.0`), values and a standalone Ingress here.

## Public on purpose

No tinyauth middleware. The viewer is meant to be shared with anyone, so nothing sits in front of it; the ingress mirrors the other public ones (audiobookshelf, ntfy). The upload/admin surface will be a separate, tinyauth-gated ingress later. The ingress file says the same in a comment so nobody "fixes" it.

## DNS — done

`A itineris 88.214.24.194` was added to `records.txt` in `oh-my-dns` (commit `9b43dc7`); the sync run created it and both Cloudflare authoritative servers (`kami`, `sri`) answer `88.214.24.194`, DNS-only like every other homelab host. Nothing to do before merging.

## What merging does

deploy-stuff renders `kubernetes/` with `--enable-helm`, pulls chart `0.1.0` from GHCR — **public**, verified with an anonymous registry token, so no pull secret is needed — and applies Deployment + Service + Ingress in `apps`. cert-manager's HTTP-01 challenge can pass immediately since the record already resolves. Stateless: no PVC, no Secret, nothing for Velero.

## Verified

- `v0.1.0` tag run published chart `0.1.0` (appVersion `0.1.0`) and image `ghcr.io/rounakdatta/itineris:0.1.0`
- `kustomize build --enable-helm kubernetes/apps/itineris` against the published chart renders: image `:0.1.0`, `runAsUser: 101`, `readOnlyRootFilesystem: true`, all capabilities dropped, `/healthz` readiness + liveness, zero tinyauth references
- **Whole-tree** `kustomize build --enable-helm kubernetes/` — the exact command CI runs — renders with itineris added and everything else intact (187 objects)
- nginx config exercised live against the built site: cache headers per path, SPA fallback, gzip, security headers on every location, `server_tokens off`
- DNS resolves authoritatively (see above)

## Deliberately not included

- **NetworkPolicy.** agentfest's only allows kube-system→pod and agentfest has no probes; itineris has probes, and kubelet probe traffic under k3s's netpol enforcer has no precedent in this cluster. A wrong guess is a NotReady pod on launch day, for a pod that serves public content anyway. Revisit once probe traffic is confirmed.
- **Keel annotations.** Chart-pinned like agentfest/texas-fold-em; a bump is a two-line PR (`version` in kustomization.yaml, `image.tag` in values.yaml).

Commits are unsigned (pinentry has no TTY where this was authored); re-sign before merging if you want the signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
