### PR TITLE
itineris 0.2.0: tinyauth-gated /admin for uploads, journal on a PVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ My homelab is a single-node x64 (previously ARM) machine, and applications are d
 | Synt           | LLM chat archiving                                         | https://github.com/rounakdatta/synt      |
 | texas-fold-em  | fold.money refresh-token broker (in-cluster API)           | https://github.com/rounakdatta/texas-fold-em |
 | Hugo sites     | Personal static sites (rounak2018 / rounak2020 / rounak2025) | https://gohugo.io/                       |
-| itineris       | Travel journal: map, timeline, photo wall, stories (public) | https://github.com/rounakdatta/itineris |
+| itineris       | Travel journal: map, timeline, photo wall, stories (public); tinyauth-gated /admin for uploads | https://github.com/rounakdatta/itineris |
 
 ### Supporting infrastructure
 

--- a/kubernetes/apps/itineris/ingress-admin.yaml
+++ b/kubernetes/apps/itineris/ingress-admin.yaml
@@ -1,0 +1,43 @@
+---
+# The admin -- uploads and tagging -- behind tinyauth, on the SAME host as the
+# public viewer.
+#
+# Traefik attaches middlewares per router, and each Ingress object is its own
+# router. So this second object (path /admin, tinyauth middleware, admin
+# Service) coexists with ingress.yaml's open / router: the longer path rule
+# wins priority, /admin never reaches nginx, and / never needs a login.
+# texas-fold-em uses the same path-scoped pattern on fold.taptappers.club.
+#
+# The admin is a separate pod, not a path inside the public nginx, so this gated
+# router is the ONLY way to reach upload code -- no path trick against the
+# public pod can get there. The admin process additionally refuses any request
+# lacking the Remote-Email header tinyauth injects.
+#
+# No cert-manager annotation on purpose: ingress.yaml owns the certificate for
+# this host; this object only reuses its secret so the router is TLS. Two
+# issuers for one secret would fight.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: itineris-admin
+  namespace: apps
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.middlewares: tinyauth-tinyauth@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: itineris.taptappers.club
+    http:
+      paths:
+      - path: /admin
+        pathType: Prefix
+        backend:
+          service:
+            name: itineris-admin
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - itineris.taptappers.club
+    secretName: itineris-tls-secret

--- a/kubernetes/apps/itineris/ingress.yaml
+++ b/kubernetes/apps/itineris/ingress.yaml
@@ -8,9 +8,9 @@
 # is expected to be privacy-scrubbed at BUILD time (route starts/ends clipped,
 # home fuzzed, EXIF stripped) rather than hidden at the edge.
 #
-# The upload / admin surface is a separate concern and will get its own
-# ingress behind tinyauth when it exists. Do not "fix" this one by adding the
-# middleware -- that would lock out every person the link was shared with.
+# The upload / admin surface has its own ingress behind tinyauth: see
+# ingress-admin.yaml. Do not "fix" this one by adding the middleware -- that
+# would lock out every person the link was shared with.
 #
 # Mirrors the other public ingresses (audiobookshelf, ntfy): cert-manager TLS
 # on the websecure entrypoint, nothing else.

--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,10 +10,11 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.0
+    version: 0.2.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml
 
 resources:
   - ingress.yaml
+  - ingress-admin.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -3,8 +3,8 @@
 #
 # itineris is a static travel journal -- map, timeline, photo wall and
 # Instagram-style stories -- served by nginx from an image that IS the site.
-# No state, no database, no secrets: a redeploy is a new image tag, and there
-# is nothing here for Velero to back up.
+# No database, no secrets. State is one PVC -- originals, derivatives and the
+# journal -- which Velero backs up nightly like every other PVC.
 
 image:
   repository: ghcr.io/rounakdatta/itineris
@@ -12,7 +12,24 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.1.0"
+  tag: "0.2.0"
+
+# Photos, derivatives and the journal. local-path is advisory only (no quota
+# enforcement): the real limit is the node's free disk, so treat the size as
+# documentation of intent. Node-local, so this pins both itineris pods to
+# whichever node first schedules them.
+persistence:
+  enabled: true
+  size: 50Gi
+
+# Uploads + tagging at /admin, behind tinyauth via ingress-admin.yaml. The
+# empty allowlist means tinyauth's whitelist is the gate, same as every other
+# app in this cluster.
+admin:
+  enabled: true
+  image:
+    tag: "0.2.0"
+  allowedEmails: ""
 
 # Deliberately unpinned, matching every app except frigate/ntfy: those two
 # carry homelab.setup/city=rishra because they belong to that physical


### PR DESCRIPTION
Adds the **upload + tagging admin** for itineris at `/admin`, behind tinyauth, on the same host as the public viewer — and moves the journal onto a PVC so uploads persist.

## How the gating works

Two Ingress objects on `itineris.taptappers.club`: `ingress.yaml` (`/`, no middleware → nginx) and the new `ingress-admin.yaml` (`/admin`, `tinyauth-tinyauth@kubernetescrd` → the separate `itineris-admin` Service). Traefik gives each its own router and the longer path rule wins, so `/` stays public and `/admin` needs a login. texas-fold-em already uses the path-scoped half of this on `fold.taptappers.club`. The admin is a **separate pod**, not a path in nginx, so the gated router is the only way to reach upload code; the process also 401s any request lacking tinyauth's `Remote-Email` header.

## What merging does

- Creates PVC `itineris-data` (50Gi advisory, `local-path`, `resource-policy: keep`; Velero backs it up nightly like every PVC).
- Rolls the public Deployment to `0.2.0`: an initContainer seeds the volume from the image **once** (sentinel file, deliberately not `cp -u`), then nginx mounts `data/` and `media/` read-only. RollingUpdate — the old pod serves until the new one is Ready.
- Adds Deployment/Service `itineris-admin` (`0.2.0`), `Recreate` strategy (single writer).
- Adds the gated Ingress. No cert-manager annotation on it; it reuses the host's secret.

## Verified

- Chart `0.2.0` (appVersion `0.2.0`) and images `itineris:0.2.0`, `itineris-admin:0.2.0` public on GHCR, anonymous pull confirmed
- `kustomize build --enable-helm kubernetes/apps/itineris` against the published chart: 7 objects, exactly one tinyauth reference (the admin ingress), exactly one cert-manager annotation (the public one)
- Whole-tree `kustomize build --enable-helm kubernetes/` renders
- Server exercised live by a harness that forges JPEGs with EXIF/GPS: identity required, time zones (EXIF offset / GPS-derived / unknown), EXIF-free derivatives, dedup, edit validation, atomic writes, delete keeps original
- nginx harness re-run with the new caching (`/data` no-cache, `/media` immutable)

## After merge, check

`/admin` → 401/302 to auth (gated); `/` → 200; `/data/moments.json` → 200 **from the volume**. If the last one fails while the pod is Ready, revert this PR — that is the one regression the probe cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
