### PR TITLE
itineris: 0.2.0 -> 0.2.1 (admin pod /tmp for libvips, 1Gi limit)

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.2.0
+    version: 0.2.1
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.2.0"
+  tag: "0.2.1"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -28,7 +28,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.2.0"
+    tag: "0.2.1"
   allowedEmails: ""
 
 # Deliberately unpinned, matching every app except frigate/ntfy: those two


### PR DESCRIPTION
Chart and both images to `0.2.1`. The admin container has a read-only rootfs and libvips spills decoded images over ~100 MB (a 24–48 MP phone photo) to temp files, so without a `/tmp` mount the first large upload would fail. Adds an emptyDir at `/tmp`, raises the memory limit to 1Gi, and sharp now runs single-threaded with no cache. No ingress or data changes; the PVC is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)