### PR TITLE
itineris: 0.2.1 -> 0.3.0 (galleries; uploads private by default)

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.2.1
+    version: 0.3.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.2.1"
+  tag: "0.3.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -28,7 +28,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.2.1"
+    tag: "0.3.0"
   allowedEmails: ""
 
 # Deliberately unpinned, matching every app except frigate/ntfy: those two


### PR DESCRIPTION
Chart and both images to `0.3.0`.

**Galleries.** Uploads are private by default. The library moves to a never-served `library/`; the admin materialises a whitelist projection per gallery into `data/galleries/<token>.json`. Each gallery is an unguessable `/g/<token>` link, a photo can be in many, one is *home* and shown at `/`.

**Migration on this volume, automatic on the admin's first boot:** the 0.2 public `data/moments.json` becomes the library, wrapped in one home gallery ("My journal") so `/` keeps showing what it showed; the public copy is then removed. While the new admin pod pulls its image, `/` shows a landing card for a few seconds.

**Verified:** 52 component tests, the server harness (fresh, legacy-migration and existing volumes, privacy projection), and a headless-Chromium end-to-end run with screenshots — all in CI or locally before the tag. Rendered here against the published chart: images `0.3.0` ×3, init seeds `library/`, sentinel accepts both layouts, one tinyauth reference.

**After merge, check:** `/data/home.json` → 200 with a token; `/data/moments.json` → **404**; `/` → 20 photos; `/admin/` still gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)