### PR TITLE
ci: read-only cluster-status workflow

### DIFF
--- a/.github/workflows/cluster-status.yml
+++ b/.github/workflows/cluster-status.yml
@@ -1,0 +1,71 @@
+name: Cluster status (read-only)
+
+# Diagnostics on demand: nodes and their conditions, every pod that is not
+# Running with the events behind it, PV node affinity, recent events, usage.
+# Every command is a get, describe or top -- this workflow never mutates
+# anything. It exists because the deploy log's pod listing is otherwise the
+# only view of the cluster from outside the tailnet.
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: 'Namespace whose non-running pods get described'
+        required: false
+        default: 'apps'
+        type: string
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          version: 1.76.1
+          args: --advertise-tags=tag:homelab
+
+      - name: Fetch kubeconfig via Tailscale SSH
+        env:
+          CONTROL: ${{ secrets.CONTROL_MACHINE_NAME }}
+        run: |
+          mkdir -p ~/.kube
+          tailscale ssh "root@${CONTROL}" "cat /etc/rancher/k3s/k3s.yaml" > ~/.kube/config
+          sed -i "s|https://127.0.0.1:6443|https://${CONTROL}:6443|g" ~/.kube/config
+          kubectl cluster-info | head -1
+
+      - name: Nodes
+        run: |
+          kubectl get nodes -o wide
+          echo
+          kubectl get nodes -o custom-columns='NODE:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,REASON:.status.conditions[?(@.type=="Ready")].reason,LAST-HEARTBEAT:.status.conditions[?(@.type=="Ready")].lastHeartbeatTime,MEM-PRESSURE:.status.conditions[?(@.type=="MemoryPressure")].status,DISK-PRESSURE:.status.conditions[?(@.type=="DiskPressure")].status,TAINTS:.spec.taints[*].key'
+          echo
+          kubectl get nodes -o custom-columns='NODE:.metadata.name,LABELS:.metadata.labels' | sed 's/map\[//; s/\]//; s/ /\n        /g'
+
+      - name: Pods that are not Running, with events
+        env:
+          NS: ${{ inputs.namespace }}
+        run: |
+          kubectl get pods -A -o wide | grep -vE ' (Running|Completed) ' || true
+          echo
+          for p in $(kubectl -n "$NS" get pods -o json | jq -r '.items[] | select(.status.phase != "Running" or .metadata.deletionTimestamp != null) | .metadata.name'); do
+            echo "=================== $p ==================="
+            kubectl -n "$NS" describe pod "$p" | sed -n '/^Node:/p; /^Status:/p; /^Reason:/p; /^Events:/,$p'
+            echo
+          done
+
+      - name: Volumes and where they live
+        run: |
+          kubectl get pv -o custom-columns='PV:.metadata.name,CLAIM:.spec.claimRef.namespace/.spec.claimRef.name,NODE-AFFINITY:.spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].values[0],PHASE:.status.phase,SIZE:.spec.capacity.storage'
+          echo
+          kubectl get pvc -A
+
+      - name: Recent events
+        run: kubectl get events -A --sort-by=.lastTimestamp | tail -45
+
+      - name: Resource usage
+        run: |
+          kubectl top nodes || true
+          echo
+          kubectl describe nodes | grep -A8 '^Allocated resources:' || true


### PR DESCRIPTION
Dispatch-only diagnostics: node conditions and labels, every non-Running pod in a namespace with its events, PV node affinity, recent events, resource usage. Only `get`/`describe`/`top` — nothing is mutated. A new workflow file does not trigger deploy-stuff.

Motivation: itineris and the rishra-pinned apps (frigate, home-assistant, ntfy) went Terminating/Pending together at ~06:00 UTC and the site is 503; the deploy log cannot say why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)