### PR TITLE
itineris: pin to the control plane with a fresh volume (site is 503)

### DIFF
--- a/.github/workflows/deploy-stuff.yml
+++ b/.github/workflows/deploy-stuff.yml
@@ -87,6 +87,15 @@ jobs:
           kubectl -n default delete deploy velero-ui --ignore-not-found
           kubectl -n default delete svc velero-ui --ignore-not-found
 
+          # One-time (2026-09-05): itineris's pods lived on the rishra worker
+          # `jomjom`, which went unreachable mid-rollout. Their API objects are
+          # stuck Terminating because no kubelet can confirm the termination,
+          # and the admin's Recreate strategy waits for them forever. Remove the
+          # objects; if jomjom comes back, its kubelet finds them gone and stops
+          # the containers. Idempotent: --ignore-not-found.
+          kubectl -n apps delete pod itineris-5996f6554f-xjvd2 itineris-admin-58dd796495-gr6vm \
+            --force --grace-period=0 --ignore-not-found
+
           # First apply may fail for Velero/cert-manager CRs if CRDs haven't propagated yet
           kubectl apply -f /tmp/manifest.yaml || true
           # Wait for any CRDs to be established

--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -18,3 +18,4 @@ helmCharts:
 resources:
   - ingress.yaml
   - ingress-admin.yaml
+  - pvc.yaml

--- a/kubernetes/apps/itineris/pvc.yaml
+++ b/kubernetes/apps/itineris/pvc.yaml
@@ -1,0 +1,26 @@
+---
+# The journal's volume, declared here rather than by the chart so its name can
+# change when it has to move.
+#
+# local-path is node-local: a claim binds to whichever node its first consumer
+# lands on and stays there for good. The chart's own claim (itineris-data)
+# bound to the rishra worker `jomjom` on 2026-09-05 because nothing pinned the
+# pods, and that node -- a home box on the far end of a Tailscale link -- went
+# unreachable mid-rollout and took the public site down with it. This claim
+# binds on the control-plane node (values.yaml pins both pods there).
+#
+# itineris-data is deliberately left alone (the chart gave it
+# helm.sh/resource-policy: keep): anything on it can be copied here once jomjom
+# is reachable again.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: itineris-data-cp
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 50Gi

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -20,7 +20,9 @@ image:
 # whichever node first schedules them.
 persistence:
   enabled: true
-  size: 50Gi
+  # Declared in pvc.yaml (see the story there); the chart's own claim,
+  # itineris-data, is stranded on the rishra worker and kept for recovery.
+  existingClaim: itineris-data-cp
 
 # Uploads + tagging at /admin, behind tinyauth via ingress-admin.yaml. The
 # empty allowlist means tinyauth's whitelist is the gate, same as every other
@@ -31,7 +33,12 @@ admin:
     tag: "0.3.0"
   allowedEmails: ""
 
-# Deliberately unpinned, matching every app except frigate/ntfy: those two
-# carry homelab.setup/city=rishra because they belong to that physical
-# location. This is general serving and belongs on the main node.
-nodeSelector: {}
+# Pinned to the control-plane node, unlike most apps here. Unpinned, the
+# scheduler put itineris on the rishra worker `jomjom` at its very first deploy,
+# the local-path volume then bound there, and every rollout was forced back to
+# a node that is unreachable whenever that house's link is -- which is how the
+# public site went 503 on 2026-09-05. A site meant to be shared belongs on the
+# node that is always there. (frigate/ntfy/home-assistant carry city=rishra on
+# purpose; that is the other side of the same coin.)
+nodeSelector:
+  node-role.kubernetes.io/control-plane: "true"


### PR DESCRIPTION
**Incident.** `jomjom` (the rishra worker) went NotReady at 05:55 UTC. Every Terminating pod is on it — frigate, home-assistant, ntfy (pinned there by design) and **both itineris pods**. itineris was never pinned: the scheduler placed it on jomjom at 0.1.0, the local-path PVC bound there at 0.2.0, and every rollout since was forced back. Result: old pods stuck Terminating, new pods unschedulable, `/` → 503. Diagnosed with the new read-only `cluster-status` workflow (#156).

**Fix.** `nodeSelector: node-role.kubernetes.io/control-plane` on both pods and a new claim `itineris-data-cp` (pvc.yaml) that binds on the control plane. The image seeds it with the demo gallery. `itineris-data` on jomjom is **kept** (resource-policy keep) so anything uploaded there can be copied over when the node returns. deploy-stuff gets a one-time, idempotent force-removal of the two pod objects stuck on the unreachable node — the admin's `Recreate` strategy otherwise waits forever.

**Also seen, not touched:** a stale node object `rounak` (NotReady since 29 Jul, the pre-migration VM) — `kubectl delete node rounak` when convenient. frigate/home-assistant/ntfy stay down until jomjom is back; that is by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)