### PR TITLE
itineris: 0.3.0 -> 0.4.0 (offline: upload queue, service workers, save for offline)

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.3.0
+    version: 0.4.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.3.0"
+  tag: "0.4.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.3.0"
+    tag: "0.4.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Chart and both images to `0.4.0`; no manifest changes beyond the pins.

**Offline layer (in the images).** Uploads go into IndexedDB the moment they are picked and upload one per request with exponential backoff, an `online` wake-up and a Retry button; they can be captioned/tagged while queued; a 401 pauses the queue for a sign-in. Both apps get a service worker: shell precached, data network-first with the last copy as fallback (`X-Itineris-Cache: fallback`), photos and map tiles cache-first; the viewer has *Save for offline* for a whole gallery and is installable.

**Serving.** `/sw.js` falls under nginx's `no-cache` location so updates propagate; `/admin/sw.js` is served `no-cache` by the admin and stays behind tinyauth — a browser's worker-script fetch carries the session cookie, and Traefik injects the identity for the worker's own fetches, exactly like page requests.

**Verified before the tag:** 75 unit tests (incl. the queue on a fake IndexedDB and the worker's routing), the server harness, and a headless-Chromium run that cuts the network after picking photos, annotates offline, brings back a 502-ing server, reloads mid-outage, then kills nginx and reopens a saved gallery from the worker's cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)