### PR TITLE
itineris: 0.4.0 -> 0.4.1 (manifest types; admin manifest fetched with credentials)

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.4.0
+    version: 0.4.1
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.4.0"
+  tag: "0.4.1"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.4.0"
+    tag: "0.4.1"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Patch release, pins only. nginx now serves `/manifest.webmanifest` as `application/manifest+json`; the admin's manifest link carries `crossorigin=use-credentials` so it is fetched with the tinyauth cookie and *install to home screen* works behind the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)