### PR TITLE
itineris: 0.4.1 -> 0.4.2 (offline sheet copy)

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.4.1
+    version: 0.4.2
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.4.1"
+  tag: "0.4.2"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.4.1"
+    tag: "0.4.2"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Pins only. Fixes a swallowed space in the *Save for offline* sheet. The production offline proof (`npm run check:live`) passed against 0.4.1: worker installed on the live site, gallery saved (20 photos + map to zoom 14, 17 MB), then reopened from cache with the site and the map CDN unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)