### PR TITLE
itineris: 0.4.2 -> 0.5.0 (progressive stories, 960px tier, no-location galleries, bulk location)

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.4.2
+    version: 0.5.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.4.2"
+  tag: "0.5.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.4.2"
+    tag: "0.5.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Pins only; the changes live in the images.

From two screenshots taken on a phone at 2 KB/s: a story that showed only a dark blur (the blurred backdrop had loaded, the 1600px image had not, and the timer ran anyway), and a San Francisco gallery whose map showed Singapore (hardcoded default camera, an initial-fit race against a worker-cached style, and photos that arrived without GPS because phones strip location from browser-picked photos).

Now: thumbnail shown sharp at once with the full image fading in, a 960px tier for phones, a spinner and an explicit failure state, timer gated on the image (and measured on the frame clock — the first delta was negative); the map starts on a world view, refits whenever data arrives, a gallery with no locations opens on the wall and says so; the admin gets a one-row bulk bar with **Location** for a whole selection and a hint about phones stripping GPS.

Verified: 84 unit tests, the server harness, 72 browser assertions including the no-GPS gallery flow end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)