### PR TITLE
cluster-status: show itineris admin startup/backfill lines (identities hidden)

### DIFF
--- a/.github/workflows/cluster-status.yml
+++ b/.github/workflows/cluster-status.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Recent events
         run: kubectl get events -A --sort-by=.lastTimestamp | tail -45
+      - name: itineris admin (startup + background jobs; filtered, identities hidden)
+        run: kubectl -n apps logs deploy/itineris-admin --tail=200 2>/dev/null | grep -E '^itineris admin on|backfill' | sed -E 's/allowlist=.*/allowlist=(hidden)/' || true
 
       - name: Resource usage
         run: |


### PR DESCRIPTION
Read-only: adds the itineris admin's startup and backfill log lines to the diagnostics run, with the allowlist masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)