### PR TITLE
itineris 0.5.2

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.5.1
+    version: 0.5.2
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.5.1"
+  tag: "0.5.2"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.5.1"
+    tag: "0.5.2"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Bumps itineris chart + images to 0.5.2: fixes the dark story for landscape photos (the blurred backdrop was painted over the photo — a stacking-context bug, proven and guarded by a pixel-level e2e), adds place search (Nominatim) and "My location" to every location picker and to the upload queue, and stamps the app version in the viewer's ⤓ sheet.

Merge after the v0.5.2 image/chart run on itineris has published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)