### PR TITLE
itineris 0.6.0

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.5.2
+    version: 0.6.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.5.2"
+  tag: "0.6.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.5.2"
+    tag: "0.6.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Bumps itineris chart + images to 0.6.0: Google Maps links in (paste or share a place; the admin is a Web Share Target) and out (place card + story header link to the exact place), no API key or quota involved.

Merge after the v0.6.0 image/chart run on itineris has published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)