### PR TITLE
node-maintenance: leader-election tuning for k3s on slow storage (explicit input)

### DIFF
--- a/.github/workflows/cluster-status.yml
+++ b/.github/workflows/cluster-status.yml
@@ -53,7 +53,7 @@ jobs:
               # no iotop/pidstat: sample /proc/<pid>/io write_bytes over 5 s for the busiest processes
               for p in /proc/[0-9]*; do r1=$(awk '/^read_bytes/{print $2}' $p/io 2>/dev/null); w1=$(awk '/^write_bytes/{print $2}' $p/io 2>/dev/null); [ -n "$w1" ] && echo "$(basename $p) $r1 $w1"; done > /tmp/io1; sleep 5
               for p in /proc/[0-9]*; do r2=$(awk '/^read_bytes/{print $2}' $p/io 2>/dev/null); w2=$(awk '/^write_bytes/{print $2}' $p/io 2>/dev/null); [ -n "$w2" ] && echo "$(basename $p) $r2 $w2"; done > /tmp/io2
-              join /tmp/io1 /tmp/io2 | awk '{ d=($4-$2)+($5-$3); if (d>0) printf "%d MB/5s pid %s %s\n", d/1048576, $1, "" }' | sort -n -r | head -10 | while read mb u pid _; do echo "$mb $u pid $pid $(tr '\0' ' ' < /proc/$pid/cmdline 2>/dev/null | cut -c1-90)"; done
+              join /tmp/io1 /tmp/io2 | awk '{ d=($4-$2)+($5-$3); if (d>0) printf "%d %s\n", d/1048576, $1 }' | sort -n -r | head -10 | while read mb pid; do echo "${mb} MB/5s  pid ${pid}  $(tr '\0' ' ' < /proc/${pid}/cmdline 2>/dev/null | cut -c1-90)"; done
               rm -f /tmp/io1 /tmp/io2
             fi
             echo "== velero: backups in progress? (may fail if the API is down) =="

--- a/.github/workflows/node-maintenance.yml
+++ b/.github/workflows/node-maintenance.yml
@@ -19,6 +19,10 @@ on:
         description: 'Trim the systemd journal to 300M'
         type: boolean
         default: false
+      tune_leader_election:
+        description: 'k3s on slow storage: let controllers survive slow etcd (lease 60s / renew 45s / retry 10s) via a config.yaml.d drop-in, then restart k3s once'
+        type: boolean
+        default: false
 
 jobs:
   maintain:
@@ -46,6 +50,51 @@ jobs:
         if: ${{ inputs.vacuum_journal }}
         run: |
           tailscale ssh "root@${CONTROL}" 'journalctl --vacuum-size=300M 2>&1 | tail -n 2'
+
+      # The controllers embedded in k3s renew a 15 s lease every 10 s; when etcd
+      # takes seconds per request they lose it and k3s exits ("leaderelection
+      # lost"), and the restart makes the disk even busier. Longer leases are
+      # the documented mitigation for k3s on slow disks. Written as a drop-in
+      # (config.yaml.d, k3s >= 1.24) only when config.yaml does not already set
+      # these keys, so nothing of the existing configuration is replaced;
+      # `rm /etc/rancher/k3s/config.yaml.d/10-leader-election.yaml` reverts it.
+      - name: Tune leader election for slow storage
+        if: ${{ inputs.tune_leader_election }}
+        run: |
+          tailscale ssh "root@${CONTROL}" 'bash -s' <<'EOS'
+            set -e
+            v="$(k3s --version | head -1)"; echo "$v"
+            minor="$(echo "$v" | sed -E 's/.*v1\.([0-9]+)\..*/\1/')"
+            if [ -z "$minor" ] || [ "$minor" -lt 24 ]; then echo "k3s too old for config.yaml.d; not touching it"; exit 0; fi
+            if [ -f /etc/rancher/k3s/config.yaml ] && grep -qE '^(kube-controller-manager-arg|kube-scheduler-arg|kube-cloud-controller-manager-arg)' /etc/rancher/k3s/config.yaml; then
+              echo "config.yaml already sets controller/scheduler args -- merge by hand instead"; exit 0
+            fi
+            mkdir -p /etc/rancher/k3s/config.yaml.d
+            cat > /etc/rancher/k3s/config.yaml.d/10-leader-election.yaml <<'YAML'
+          # Added 2026-09-06: etcd on this disk fsyncs in ~100 ms; with the default
+          # 15 s lease / 10 s renew deadline the controllers lost leadership and k3s
+          # exited every few minutes. Delete this file to revert.
+          kube-controller-manager-arg:
+            - leader-elect-lease-duration=60s
+            - leader-elect-renew-deadline=45s
+            - leader-elect-retry-period=10s
+          kube-scheduler-arg:
+            - leader-elect-lease-duration=60s
+            - leader-elect-renew-deadline=45s
+            - leader-elect-retry-period=10s
+          kube-cloud-controller-manager-arg:
+            - leader-elect-lease-duration=60s
+            - leader-elect-renew-deadline=45s
+            - leader-elect-retry-period=10s
+          YAML
+            echo "drop-in written; restarting k3s once"
+            before="$(systemctl show k3s -p NRestarts --value)"
+            systemctl restart k3s
+            sleep 25
+            systemctl is-active k3s
+            echo "restart counter: $before -> $(systemctl show k3s -p NRestarts --value) (a manual restart does not count)"
+            journalctl -u k3s --since '-2 min' --no-pager | grep -m1 -oE 'Running kube-controller-manager .*leader-elect-lease-duration=[0-9a-z]+' | sed -E 's/--(client-ca-file|authentication-kubeconfig|authorization-kubeconfig|kubeconfig|service-account-private-key-file|root-ca-file|cluster-signing[a-z-]*)=[^ ]+ ?//g' | cut -c1-300
+          EOS
 
       - name: After
         run: |


### PR DESCRIPTION
Explicit, reversible mitigation for k3s exiting with "leaderelection lost" on a disk where etcd fsync averages ~95 ms: longer leader-election leases via a config.yaml.d drop-in, one controlled k3s restart. Off by default. Plus a fix to the doctor's I/O sampler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)