### PR TITLE
itineris 0.7.0: Google Maps as the map (key via Bitwarden → Secret)

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -213,6 +213,15 @@
           db-username: nextcloud/db_username
           db-password: nextcloud/db_password
 
+      # itineris: Google Maps JavaScript API key for the viewer. A browser key
+      # (every visitor's browser receives it), protected by its HTTP-referrer
+      # restriction in Google Cloud, not by secrecy -- kept out of git all the
+      # same. Bitwarden item `itineris/google_maps_api_key`, password = the key.
+      - name: itineris-google-maps
+        namespace: apps
+        data:
+          apiKey: itineris/google_maps_api_key
+
       # Frigate RTSP credentials. Keys are the env var names Frigate looks
       # up at runtime when substituting `{FRIGATE_RTSP_USERNAME}` /
       # `{FRIGATE_RTSP_PASSWORD}` placeholders in cameras[].ffmpeg.inputs[].path.

--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.6.0
+    version: 0.7.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.6.0"
+  tag: "0.7.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.6.0"
+    tag: "0.7.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the
@@ -42,3 +42,10 @@ admin:
 # purpose; that is the other side of the same coin.)
 nodeSelector:
   node-role.kubernetes.io/control-plane: "true"
+
+# Google Maps as the map. The browser key comes from the Secret the Bitwarden
+# sync creates (see ansible/playbook.yml, item itineris/google_maps_api_key),
+# never from this file: this repo is public. Until the Secret exists the site
+# draws MapLibre; the next deploy after it lands switches to Google Maps.
+googleMaps:
+  existingSecret: itineris-google-maps


### PR DESCRIPTION
- Chart 0.7.0: the viewer draws **Google Maps** (photo pins, routes) when a key is present, MapLibre otherwise/offline.
- The Maps JavaScript API key is a browser key protected by its referrer restriction; it still stays out of this public repo: `googleMaps.existingSecret: itineris-google-maps`, produced by the Bitwarden sync from item `itineris/google_maps_api_key`. Until that item exists the sync reports it (run goes red at the end) and the site keeps drawing MapLibre; the deploy after it lands switches the map.

Merge after the v0.7.0 chart/image run on itineris has published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)