### PR TITLE
deploy: restart the itineris viewer when its Google Maps key changes; maintenance: explicit rollout restart

### DIFF
--- a/.github/workflows/deploy-stuff.yml
+++ b/.github/workflows/deploy-stuff.yml
@@ -56,8 +56,12 @@ jobs:
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: |
-          kubectl create secret generic itineris-google-maps --namespace=apps \
-            --from-literal=apiKey="$GOOGLE_MAPS_API_KEY" --dry-run=client -o yaml | kubectl apply -f -
+          out="$(kubectl create secret generic itineris-google-maps --namespace=apps \
+            --from-literal=apiKey="$GOOGLE_MAPS_API_KEY" --dry-run=client -o yaml | kubectl apply -f -)"
+          echo "$out"
+          # The viewer reads the Secret once, at pod start (init container -> /config.json):
+          # a new or changed key needs the pod to start again.
+          case "$out" in *created*|*configured*) kubectl -n apps rollout restart deployment/itineris && kubectl -n apps rollout status deployment/itineris --timeout=180s || true;; esac
           # this Secret is accounted for now; drop it from the not-synced list
           if [ -s /tmp/secret-sync-failures.txt ]; then grep -v '^itineris-google-maps ' /tmp/secret-sync-failures.txt > /tmp/secret-sync-failures.new || true; mv /tmp/secret-sync-failures.new /tmp/secret-sync-failures.txt; fi
 

--- a/.github/workflows/node-maintenance.yml
+++ b/.github/workflows/node-maintenance.yml
@@ -19,6 +19,10 @@ on:
         description: 'Trim the systemd journal to 300M'
         type: boolean
         default: false
+      rollout_restart:
+        description: 'Restart one deployment (namespace/name, e.g. apps/itineris) so it picks up a changed Secret or ConfigMap'
+        type: string
+        default: ''
       tune_leader_election:
         description: 'k3s on slow storage: let controllers survive slow etcd (lease 60s / renew 45s / retry 10s) via a config.yaml.d drop-in, then restart k3s once'
         type: boolean
@@ -95,6 +99,18 @@ jobs:
             echo "restart counter: $before -> $(systemctl show k3s -p NRestarts --value) (a manual restart does not count)"
             journalctl -u k3s --since '-2 min' --no-pager | grep -m1 -oE 'Running kube-controller-manager .*leader-elect-lease-duration=[0-9a-z]+' | sed -E 's/--(client-ca-file|authentication-kubeconfig|authorization-kubeconfig|kubeconfig|service-account-private-key-file|root-ca-file|cluster-signing[a-z-]*)=[^ ]+ ?//g' | cut -c1-300
           EOS
+
+      - name: Rollout restart
+        if: ${{ inputs.rollout_restart != '' }}
+        env:
+          TARGET: ${{ inputs.rollout_restart }}
+        run: |
+          case "$TARGET" in
+            [a-z0-9-]*/[a-z0-9-]*) ;;
+            *) echo "::error::rollout_restart must be namespace/name"; exit 1;;
+          esac
+          ns="${TARGET%%/*}"; name="${TARGET#*/}"
+          tailscale ssh "root@${CONTROL}" "k3s kubectl -n '$ns' rollout restart deployment/'$name' && k3s kubectl -n '$ns' rollout status deployment/'$name' --timeout=240s"
 
       - name: After
         run: |


### PR DESCRIPTION
A created/changed `itineris-google-maps` Secret restarts the viewer deployment (its init container renders /config.json at start). Plus an explicit `rollout_restart` input (namespace/name) on the maintenance workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)