### PR TITLE
itineris 0.8.0: places as pins

### DIFF
--- a/.github/workflows/deploy-stuff.yml
+++ b/.github/workflows/deploy-stuff.yml
@@ -55,13 +55,21 @@ jobs:
         if: ${{ env.GOOGLE_MAPS_API_KEY != '' }}
         env:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          # Optional server-only key for Places lookups (ratings), for when the
+          # browser key above is referrer-restricted.
+          GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY }}
         run: |
-          out="$(kubectl create secret generic itineris-google-maps --namespace=apps \
-            --from-literal=apiKey="$GOOGLE_MAPS_API_KEY" --dry-run=client -o yaml | kubectl apply -f -)"
+          args=(--from-literal=apiKey="$GOOGLE_MAPS_API_KEY")
+          [ -n "$GOOGLE_PLACES_API_KEY" ] && args+=(--from-literal=placesApiKey="$GOOGLE_PLACES_API_KEY")
+          out="$(kubectl create secret generic itineris-google-maps --namespace=apps "${args[@]}" --dry-run=client -o yaml | kubectl apply -f -)"
           echo "$out"
-          # The viewer reads the Secret once, at pod start (init container -> /config.json):
-          # a new or changed key needs the pod to start again.
-          case "$out" in *created*|*configured*) kubectl -n apps rollout restart deployment/itineris && kubectl -n apps rollout status deployment/itineris --timeout=180s || true;; esac
+          # Both pods read the Secret at start (viewer: init container -> /config.json;
+          # admin: env for Places lookups): a new or changed key needs them to start again.
+          case "$out" in *created*|*configured*)
+            kubectl -n apps rollout restart deployment/itineris deployment/itineris-admin
+            kubectl -n apps rollout status deployment/itineris --timeout=180s || true
+            kubectl -n apps rollout status deployment/itineris-admin --timeout=180s || true;;
+          esac
           # this Secret is accounted for now; drop it from the not-synced list
           if [ -s /tmp/secret-sync-failures.txt ]; then grep -v '^itineris-google-maps ' /tmp/secret-sync-failures.txt > /tmp/secret-sync-failures.new || true; mv /tmp/secret-sync-failures.new /tmp/secret-sync-failures.txt; fi
 

--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.7.0
+    version: 0.8.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.7.0"
+  tag: "0.8.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.7.0"
+    tag: "0.8.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
- Chart 0.8.0: story-ring pins with Google's rating chip; the admin looks places up server-side (Places API (New), 1,000 free/month) using the same Secret's \`apiKey\`, or a server-only \`placesApiKey\`.
- Deploy: the optional repository secret \`GOOGLE_PLACES_API_KEY\` becomes \`placesApiKey\` in the Secret; a created/changed Secret now restarts both itineris pods (the admin reads the key at start).

Merge after the v0.8.0 chart/image run on itineris has published. **Rounak: enable "Places API (New)" on the Google Cloud project**, otherwise the admin reports the refusal and the map simply shows no rating chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)