### PR TITLE
itineris 0.10.0: videos + cold-load deep links

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.9.0
+    version: 0.10.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.9.0"
+  tag: "0.10.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.9.0"
+    tag: "0.10.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Bumps the itineris chart and both images 0.9.0 → 0.10.0 (chart + images verified on GHCR).

- **Videos**: the admin image now carries ffmpeg; uploaded `.mp4`/`.mov` clips are probed for when/where, transcoded to H.264 ≤1280 + AAC, and given a poster in the photo tiers. The viewer plays them in the story (muted autoplay, sound toggle, ▶ badges).
- **Fix**: shared `#m/<id>` and `#wall` links opened the gallery instead of the story on a cold load.

The deploy's final step going red on the duplicated `keel/*` Bitwarden items is expected and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)