### PR TITLE
itineris 0.11.0: per-place stories, no place card, mute icon, no Wall toggle

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.10.1
+    version: 0.11.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.10.1"
+  tag: "0.11.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.10.1"
+    tag: "0.11.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Bumps the itineris chart and both images 0.10.1 → 0.11.0 (chart + images verified on GHCR).

- A story is one place's photos and videos (its own bars and count); the next place follows, like Instagram.
- The place card is gone: one tap on a pin, chip or thumbnail opens the story (name + rating stay on the pin and in the story header).
- Redrawn mute icon; no Wall/Map toggle (the wall only stands in when nothing has a location).

The deploy's final step going red on the duplicated `keel/*` Bitwarden items is expected and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)