### PR TITLE
itineris 0.14.0: photography caption faces + free rotation

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.13.0
+    version: 0.14.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.13.0"
+  tag: "0.14.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.13.0"
+    tag: "0.14.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Bumps the itineris chart and both images 0.13.0 → 0.14.0 (chart + images verified on GHCR).

- Five bundled caption faces chosen for photography (Playfair Display, Cormorant Garamond italic, Cinzel, Space Grotesk, Bebas Neue) replacing the handwriting and the system serif; 0.13.0's names still work.
- Captions tilt to any angle: a drag handle on the preview, a slider, or `[` / `]`.
- The service worker no longer precaches fonts, so the install stays small on a slow link.

The deploy's final step going red on the duplicated `keel/*` Bitwarden items is expected and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)