### PR TITLE
itineris 0.18.0: a few captions on one photo

### DIFF
--- a/kubernetes/apps/itineris/kustomization.yaml
+++ b/kubernetes/apps/itineris/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: apps
 helmCharts:
   - name: itineris
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.17.0
+    version: 0.18.0
     releaseName: itineris
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/itineris/values.yaml
+++ b/kubernetes/apps/itineris/values.yaml
@@ -12,7 +12,7 @@ image:
   # on purpose: it puts the deployed image next to the chart version in
   # kustomization.yaml, so a bump PR touches both lines together -- the same
   # convention agentfest follows.
-  tag: "0.17.0"
+  tag: "0.18.0"
 
 # Photos, derivatives and the journal. local-path is advisory only (no quota
 # enforcement): the real limit is the node's free disk, so treat the size as
@@ -30,7 +30,7 @@ persistence:
 admin:
   enabled: true
   image:
-    tag: "0.17.0"
+    tag: "0.18.0"
   allowedEmails: ""
 
 # Pinned to the control-plane node, unlike most apps here. Unpinned, the


### PR DESCRIPTION
Bumps the itineris chart and both images 0.17.0 → 0.18.0 (chart + images verified on GHCR).

A photo can now carry several captions (five at most), each with its own words, place, angle, face and pill. The admin styler holds all of them; the story draws them in turn. The single caption and style stay in step with the first, so alt text, list titles and older clients are unaffected.

The deploy's final step going red on the duplicated `keel/*` Bitwarden items is expected and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)