### PR TITLE
festie: 0.1.31 -> 0.1.32 (Chrome, Xvfb, agent-browser)

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.31
+    version: 0.1.32
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.31"
+  tag: "0.1.32"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this


### PR DESCRIPTION
Picks up the browser stack the `automate-mic-doctor-refresh` skill needs, so `mic doctor`'s provider logins can be finished on festie instead of handing the terminal back. Every AWS/GCP/Azure login ends at a consent page somebody has to click, and until now there was no browser here to click it with.

## Exercised before bumping, not after

The image contents and the skill were both run on the live festie via `home-manager switch` against dotfiles main — the same activation derivation (`71n5348j…`) that image `0.1.32` carries. On top of that, a **real AWS refresh from a genuinely stranded SSO session**, driven end to end from the Claude window: `aws sso login` → Google SAML (`idpid=C019o9y7a`) → password from `pass` → phone-prompt 2FA → consent → `sts get-caller-identity` green for both `default` and `lyric_production`.

Upstream: rounakdatta/agentfest#12, rounakdatta/dotfiles#101, rounakdatta/agent-smith#9 and #10.

## What lands on the node

Chrome plus `xorg-server` is a real addition to an image the README says has to pull onto the homelab quickly. And Chrome runs `--no-sandbox`, because a pod has neither a setuid `chrome-sandbox` (read-only in the nix store, so unfixable) nor an unprivileged user namespace. The container is therefore the only boundary left around a browser holding a Google session that reaches prod admin — an argument for keeping this to one machine rather than making it the default for every future agentfest release.

## Rollout

`strategy: Recreate` is already set, so the ReadWriteOnce home volume hands over cleanly — no two-pod deadlock. Expect festie to be down for the length of one pod start, and the GPG keyring to need `! festie-unlock` afterwards since the agent's cache dies with the pod.

Merging this triggers `deploy-stuff.yml` (`kubernetes/**` on `main`).