### PR TITLE
festie: 0.1.32 -> 0.1.33 (reap orphans, real /dev/shm)

### DIFF
--- a/kubernetes/apps/agentfest/kustomization.yaml
+++ b/kubernetes/apps/agentfest/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: apps
 helmCharts:
   - name: agentfest
     repo: oci://ghcr.io/rounakdatta/charts
-    version: 0.1.32
+    version: 0.1.33
     releaseName: festie
     namespace: apps
     valuesFile: values.yaml

--- a/kubernetes/apps/agentfest/values.yaml
+++ b/kubernetes/apps/agentfest/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/rounakdatta/agentfest
-  tag: "0.1.32"
+  tag: "0.1.33"
 
 # Codeman rejects unknown Host headers before any handler runs — it is a
 # DNS-rebinding guard. Tailscale's .ts.net is allowed out of the box; this


### PR DESCRIPTION
Fixes two things about this pod that the `automate-mic-doctor-refresh` work had to work around rather than solve. Upstream: rounakdatta/agentfest#13.

**PID 1 is `tini` now, so orphans get reaped.** codeman was PID 1 and is not an init, so zombies accumulated for the life of the pod — **434** after a handful of Chrome launches. They hold PIDs, and worse: `kill -0` *succeeds* on a zombie, so any wait loop probing a pid with a signal hangs forever. That turned completed provider logins into `STATUS=still-waiting` timeouts.

**`/dev/shm` is a 1Gi memory-backed emptyDir** instead of the runtime's 64Mi. That is where Chrome puts renderer shared memory, and Google's sign-in exhausts it; the renderer wedges while the browser stays up and keeps reporting the right URL, so it reads as broken automation rather than a dead page. Memory-backed, counting against a 24Gi limit — noise.

## Verified upstream before bumping

`nix build .#entrypoint` shows the built script resolving `tini-0.19.0` with `exec tini -g -- codeman web …` as its last line; `helm template` renders the mount and the emptyDir; image and chart `0.1.33` are published and pullable.

## Rollout

`Recreate`, so the RWO home volume hands over cleanly. One pod restart. The existing zombie pile clears with the restart regardless — tini is what stops it coming back.