### PR TITLE
ntfy answers at notis.taptappers.club

### DIFF
--- a/kubernetes/apps/ntfy/ingress.yaml
+++ b/kubernetes/apps/ntfy/ingress.yaml
@@ -1,4 +1,14 @@
 ---
+# ntfy answers at notis.taptappers.club (renamed from ntfy.taptappers.club,
+# 2026-09-12). A hard cutover: the old host is gone from this object, so
+# Traefik has no route for it and anything still pointed there gets a 404.
+# Every subscriber and publisher has to be repointed by hand.
+#
+# Deliberately NOT behind the tinyauth ForwardAuth middleware that fronts the
+# other apps here. ntfy's clients -- the phone app, curl publishers, webhooks
+# -- send a token or Basic credentials and cannot follow a Google OAuth
+# browser redirect, so tinyauth would break every one of them. The gate is
+# ntfy's own: auth-default-access=deny-all plus the user.db in values.yaml.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,7 +20,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-  - host: ntfy.taptappers.club
+  - host: notis.taptappers.club
     http:
       paths:
       - path: /
@@ -22,5 +32,8 @@ spec:
               number: 80
   tls:
   - hosts:
-    - ntfy.taptappers.club
-    secretName: ntfy-tls-secret
+    - notis.taptappers.club
+    # A new Secret rather than reusing ntfy-tls-secret: that one holds a cert
+    # for the old name only, and a fresh name keeps cert-manager from serving
+    # it while the new order is still being answered.
+    secretName: notis-tls-secret

--- a/kubernetes/apps/ntfy/values.yaml
+++ b/kubernetes/apps/ntfy/values.yaml
@@ -12,11 +12,16 @@ cache:
   enabled: true
   existingClaim: ntfy-cache-pvc
 
-# server.yml — chart writes a ConfigMap from this map. Mirrors the
-# previous standalone `ntfy-config` ConfigMap exactly.
+# server.yml — chart writes a ConfigMap from this map. The chart puts a
+# checksum of it on the pod template, so a change here rolls the pod on its
+# own; base-url does not need a manual restart to take effect.
+#
+# base-url must match the host the ingress serves: ntfy stamps it onto the
+# links it hands out (attachments, the web app's own config), so leaving it
+# on the old name would emit URLs that no longer route anywhere.
 config:
   sample:
-    base-url: "https://ntfy.taptappers.club"
+    base-url: "https://notis.taptappers.club"
     cache-file: "/var/cache/ntfy/cache.db"
     auth-file: "/var/cache/ntfy/user.db"
     auth-default-access: "deny-all"


### PR DESCRIPTION
Renames the host ntfy serves from `ntfy.taptappers.club` to `notis.taptappers.club`.

### A hard cutover, not an alias

The old host is gone from the Ingress, so Traefik has no route for it — anything still pointed at `ntfy.taptappers.club` gets a 404 the moment this merges. Every subscriber (phone app topics) and publisher (curl, webhooks) has to be repointed by hand.

### What changed

| File | Change |
|---|---|
| `ingress.yaml` | `host` and the TLS SAN → `notis.taptappers.club`; `secretName` → `notis-tls-secret` |
| `values.yaml` | `base-url` → `https://notis.taptappers.club` |

`base-url` has to move with the host: ntfy stamps it onto the links it hands out (attachments, the web app's own config), so leaving it on the old name would emit URLs that no longer route. The chart puts a checksum of this config on the pod template, so the Deployment rolls on its own — no manual restart.

The TLS material goes to a **new** Secret rather than reusing `ntfy-tls-secret`, which holds a cert for the old name only; a fresh name keeps cert-manager from serving that one while the new HTTP-01 order is still being answered.

### What deliberately did not change

- **The PVC.** `existingClaim: ntfy-cache-pvc` is untouched, so `cache.db` and `user.db` carry over and every existing access token keeps working.
- **No tinyauth.** ntfy stays off the ForwardAuth middleware that fronts the other apps, for the same reason it always has: its clients send a token or Basic credentials and cannot follow a Google OAuth browser redirect, so tinyauth would break all of them. The gate is ntfy's own `auth-default-access: deny-all` plus `user.db` — verified still returning 403 to anonymous reads and publishes.
- **The nodeSelector.** Still pinned to the rishra worker `jomjom`. Worth revisiting separately (that node took itineris down in #157), but moving it means a new local-path claim and re-issuing every token, so it does not belong in a rename.

### Prerequisites done

- `A notis 88.214.24.194` is live in Cloudflare via oh-my-dns `fb53623`; resolves on both 1.1.1.1 and 8.8.8.8. cert-manager's HTTP-01 solver needs this.
- `kustomize build --enable-helm kubernetes/` renders clean; no occurrence of the old host anywhere in the full tree.

### Verification plan

Deploy to the cluster from this branch via `deploy-stuff.yml` before merging, then confirm the cert issues and the new host serves while anonymous access stays denied.

The stale `A ntfy` record stays in `records.txt` for now — that sync is upsert-only, so removing the line would not delete it from Cloudflare, only stop the file describing the zone. It needs a manual delete in the dashboard once you're happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)