### PR TITLE
ntfy: real accounts, provisioned from config

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -251,6 +251,22 @@
           firefly-pat: firefly/personal_access_token
           llm-api-key: deepseek/api_key
 
+      # ntfy credentials. ntfy provisions users declaratively from config
+      # (v2.28 auth-users / auth-tokens), and the chart exposes no env block,
+      # so kubernetes/apps/ntfy/kustomization.yaml patches these two in as
+      # NTFY_AUTH_USERS / NTFY_AUTH_TOKENS. They hold a bcrypt hash and a
+      # bearer token respectively and this repo is public, which is why they
+      # come from Bitwarden rather than values.yaml.
+      #   auth-users:  rounak:$2a$10$...:admin   (hash via `ntfy user hash`)
+      #   auth-tokens: rounak:tk_...:homelab scripts
+      # The matching plaintext login lives in Bitwarden as ntfy/admin_password
+      # and is deliberately NOT synced here -- nothing in the cluster reads it.
+      - name: ntfy-credentials
+        namespace: apps
+        data:
+          auth-users: ntfy/auth_users
+          auth-tokens: ntfy/auth_tokens
+
       # tinyauth credentials (replaces authelia)
       # Keys match the env var names tinyauth reads via valueFrom in
       # kubernetes/tinyauth/values.yaml — see env: section there.

--- a/kubernetes/apps/ntfy/kustomization.yaml
+++ b/kubernetes/apps/ntfy/kustomization.yaml
@@ -16,3 +16,43 @@ helmCharts:
 
 resources:
   - ingress.yaml
+
+# ntfy creates its users from config at startup (v2.28 "provisioned users"),
+# which is what keeps accounts declarative instead of hand-made with
+# `ntfy user add` inside the pod -- those live only in user.db on a local-path
+# PVC and would not survive it.
+#
+# The credentials cannot go in values.yaml: that renders into a ConfigMap and
+# this repository is public. They are synced from Bitwarden into the
+# ntfy-credentials Secret (ansible/playbook.yml) and injected here as env vars,
+# which ntfy reads for any config key -- NTFY_AUTH_USERS is exactly auth-users.
+#
+# Chart 0.1.1 renders no `env` at all on the container, so this is an `add` of
+# the whole array rather than a `replace` of one entry (contrast webtrees,
+# which patches by index into an env list the chart does render).
+#
+# Kubernetes only expands `$(VAR)` in env values, so the `$2a$` in a bcrypt
+# hash passes through untouched -- the `$$` escaping ntfy's docs mention is a
+# docker-compose concern, not ours.
+#
+# Note these are read once at container start: changing either Bitwarden item
+# needs a `rollout_restart: apps/ntfy` via node-maintenance.yml, since a Secret
+# update alone does not restart the pod.
+patches:
+  - target:
+      kind: Deployment
+      name: ntfy
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: NTFY_AUTH_USERS
+            valueFrom:
+              secretKeyRef:
+                name: ntfy-credentials
+                key: auth-users
+          - name: NTFY_AUTH_TOKENS
+            valueFrom:
+              secretKeyRef:
+                name: ntfy-credentials
+                key: auth-tokens

--- a/kubernetes/apps/ntfy/values.yaml
+++ b/kubernetes/apps/ntfy/values.yaml
@@ -24,6 +24,14 @@ config:
     base-url: "https://notis.taptappers.club"
     cache-file: "/var/cache/ntfy/cache.db"
     auth-file: "/var/cache/ntfy/user.db"
+    # Nothing may read or publish without credentials. The accounts
+    # themselves arrive as NTFY_AUTH_USERS / NTFY_AUTH_TOKENS, patched in
+    # from the ntfy-credentials Secret by kustomization.yaml -- a bcrypt hash
+    # and a bearer token have no business in a public repo. ntfy writes the
+    # provisioned users into the auth-file below on startup.
+    #
+    # Careful: a user removed from auth-users is DELETED from user.db on the
+    # next restart, so this list is the source of truth, not an addition to it.
     auth-default-access: "deny-all"
     behind-proxy: true
 


### PR DESCRIPTION
ntfy has been refusing everyone since `auth-default-access: deny-all` went in — correct, but there were no accounts, so there was nothing to log in *as*. This adds them.

### Why not tinyauth

The clients that matter can't do an OAuth browser redirect. The ntfy phone app and any `curl` publisher send Basic credentials or a bearer token; ntfy answers both natively. Putting the ForwardAuth middleware in front would break every one of them — so ntfy keeps its own gate, now with actual users behind it.

### Why config, not `ntfy user add`

v2.28 supports **provisioned users** — accounts declared in config and written into `user.db` at startup. A hand-made `user.db` lives only on a `local-path` PVC pinned to the rishra worker and wouldn't survive losing it. Declared accounts rebuild themselves.

⚠️ The list is the **source of truth, not an addition to it**: a user removed from `auth-users` is *deleted* from the database on the next restart.

### Why Bitwarden

`values.yaml` renders into a ConfigMap and this repo is **public**, so a bcrypt hash and a bearer token can't live there. They sync from Bitwarden into `ntfy-credentials` and reach the container as env vars — ntfy accepts env for any config key, so `NTFY_AUTH_USERS` *is* `auth-users`.

| Bitwarden item | Secret key | Env var |
|---|---|---|
| `ntfy/auth_users` | `auth-users` | `NTFY_AUTH_USERS` |
| `ntfy/auth_tokens` | `auth-tokens` | `NTFY_AUTH_TOKENS` |
| `ntfy/admin_password` | — *(not synced)* | — |

The plaintext login stays in Bitwarden only; nothing in the cluster reads it.

Chart 0.1.1 renders no `env` block at all, so the patch is an `add` of the whole array — contrast `webtrees`, which patches by index into an env list the chart does render. Kubernetes only expands `$(VAR)`, so bcrypt's `$2a$` passes through untouched; the `$$` escaping ntfy's docs mention is a docker-compose concern.

### Verification

Validated against **ntfy 2.28.0 locally** — the same build the cluster runs, via `nix shell nixpkgs#ntfy-sh` — using this exact env-var shape and a fresh database:

| Case | Result |
|---|---|
| anonymous publish | `403` |
| anonymous subscribe | `403` |
| admin user + password, publish | `200` |
| access token, publish | `200` |
| wrong password | `401` |
| subscribe as user | `200`, both messages returned |
| `/v1/account` via token | `username=rounak role=admin` |

Items are in the `taptappers.club` org's `k3s` collection, resolve cleanly by name (no duplicates), and round-trip byte-identical. `kustomize build --enable-helm kubernetes/` renders clean with zero credential material.

### Operational note

These env vars are read **once at container start**. Rotating either Bitwarden item needs a `rollout_restart: apps/ntfy` via `node-maintenance.yml` — a Secret update alone won't restart the pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)